### PR TITLE
Restrict REST API

### DIFF
--- a/10up-experience.php
+++ b/10up-experience.php
@@ -322,7 +322,8 @@ function restrict_rest_api( $result ) {
 
 	return $result;
 }
-add_filter( 'rest_authentication_errors', __NAMESPACE__ . '\restrict_rest_api' );
+// Make sure this runs somewhat late but before core's cookie auth at 100
+add_filter( 'rest_authentication_errors', __NAMESPACE__ . '\restrict_rest_api', 99 );
 
 /**
  * Register restrict REST API setting.


### PR DESCRIPTION
403 the REST API for non-logged-in users, which can be lifted either via an admin UI option or on the code level (which then hides the admin UI option). The code-level lifting can be done using `remove_filter( 'rest_authentication_errors', 'tenup\restrict_rest_api', 99 )`. See #1.