### PR TITLE
Add filter to remove stream menu item

### DIFF
--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -9,7 +9,7 @@ function plugin_customizations() {
 	/**
 	 * Stream
 	 */
-	if ( is_plugin_active( 'stream/stream.php' ) ) {
+	if ( is_plugin_active( 'stream/stream.php' ) && apply_filters( 'tenup_experience_remove_stream_menu_item', true ) ) {
 
 		add_action( 'admin_init', function() {
 			remove_menu_page( 'wp_stream' );

--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -9,14 +9,14 @@ function plugin_customizations() {
 	/**
 	 * Stream
 	 */
-    
-    /**
-     * Filters whether to remove stream menu item.
-     * 
-     * @since 1.1.0
-     * 
-     * @param bool $tenup_experience_remove_stream_menu_item Whether to remove menu item. Default is true.
-     */
+	
+	/**
+	 * Filters whether to remove stream menu item.
+	 * 
+	 * @since 1.1.0
+	 * 
+	 * @param bool $tenup_experience_remove_stream_menu_item Whether to remove menu item. Default is true.
+	 */
 	$remove_menu_item = apply_filters( 'tenup_experience_remove_stream_menu_item', true );
 	
 	if ( is_plugin_active( 'stream/stream.php' ) && $remove_menu_item ) {

--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -9,7 +9,17 @@ function plugin_customizations() {
 	/**
 	 * Stream
 	 */
-	if ( is_plugin_active( 'stream/stream.php' ) && apply_filters( 'tenup_experience_remove_stream_menu_item', true ) ) {
+    
+    /**
+     * Filters whether to remove stream menu item.
+     * 
+     * @since 1.1.0
+     * 
+     * @param bool $tenup_experience_remove_stream_menu_item Whether to remove menu item. Default is true.
+     */
+	$remove_menu_item = apply_filters( 'tenup_experience_remove_stream_menu_item', true );
+	
+	if ( is_plugin_active( 'stream/stream.php' ) && $remove_menu_item ) {
 
 		add_action( 'admin_init', function() {
 			remove_menu_page( 'wp_stream' );


### PR DESCRIPTION
With the current state of experience plugin it removes stream menu item and don't give any choice making it not able to use on a client  site. This PR adds a filter which allows to keep stream menu item and removes it in default state.