### PR TITLE
Fix escaped newline characters in JS

### DIFF
--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -143,7 +143,7 @@ add_filter( 'plugin_row_meta', __NAMESPACE__ . '\plugin_meta', 100, 4 );
  * @return void
  */
 function plugin_deactivation_warning() {
-	$message = esc_html__( 'Warning: This plugin provides additional enterprise-grade protective measures such as REST API security and disabling file editing in the dashboard.\n\nAre you sure you want to deactivate?', 'tenup' );
+	$message = esc_html__( "Warning: This plugin provides additional enterprise-grade protective measures such as REST API security and disabling file editing in the dashboard.\n\nAre you sure you want to deactivate?", 'tenup' );
 	?>
 <script type="text/javascript">
 jQuery( document ).ready( function( $ ) {


### PR DESCRIPTION
When a string is wrapped in single quotes but contains a JS escape sequence (like `\n`) and run through `esc_js()`, the slashes get stripped instead of converted to their proper sequence. In this case, that means a message that contains `dashboard.nnAre you sure` instead of a line break.

Converting the string quotes to double-quotes enables the escape sequence as expected.

Fixes #29.