### PR TITLE
Feature/disallow file mod display plugin updates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9bb2336b81ba94f7c445c72f7dde043",
+    "content-hash": "50370b15f4e13857645aac460b74e890",
     "packages": [],
     "packages-dev": [
         {
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/10up/phpcs-composer.git",
-                "reference": "37345580ebd4bf137cd0d639e2a32cdb7686f96c"
+                "reference": "4ce232a05a4ad5a09d03abaf9ee55c710dd3f410"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/10up/phpcs-composer/zipball/37345580ebd4bf137cd0d639e2a32cdb7686f96c",
-                "reference": "37345580ebd4bf137cd0d639e2a32cdb7686f96c",
+                "url": "https://api.github.com/repos/10up/phpcs-composer/zipball/4ce232a05a4ad5a09d03abaf9ee55c710dd3f410",
+                "reference": "4ce232a05a4ad5a09d03abaf9ee55c710dd3f410",
                 "shasum": ""
             },
             "require": {
@@ -45,20 +45,20 @@
                     "email": "ephraim.gregor@10up.com"
                 }
             ],
-            "time": "2018-07-06T04:57:03+00:00"
+            "time": "2018-11-22T01:54:34+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec"
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
                 "shasum": ""
             },
             "require": {
@@ -96,20 +96,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-07-26T23:47:18+00:00"
+            "time": "2018-09-23T23:08:17+00:00"
         },
         {
             "name": "wimg/php-compatibility",
-            "version": "8.2.0",
+            "version": "9.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
+                "reference": "e9f4047e5edf53c88f36f1dafc0d49454ce13e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/e9f4047e5edf53c88f36f1dafc0d49454ce13e25",
+                "reference": "e9f4047e5edf53c88f36f1dafc0d49454ce13e25",
                 "shasum": ""
             },
             "require": {
@@ -127,42 +127,47 @@
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
-            "autoload": {
-                "psr-4": {
-                    "PHPCompatibility\\": "PHPCompatibility/"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                },
+                {
                     "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
                     "role": "lead"
                 }
             ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
             "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
             "keywords": [
                 "compatibility",
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-07-17T13:42:26+00:00"
+            "time": "2018-10-07T17:38:02+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "1.0.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "539c6d74e6207daa22b7ea754d6f103e9abb2755"
+                "reference": "7aa217ab38156c5cb4eae0f04ae376027c407a9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/539c6d74e6207daa22b7ea754d6f103e9abb2755",
-                "reference": "539c6d74e6207daa22b7ea754d6f103e9abb2755",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/7aa217ab38156c5cb4eae0f04ae376027c407a9b",
+                "reference": "7aa217ab38156c5cb4eae0f04ae376027c407a9b",
                 "shasum": ""
             },
             "require": {
@@ -170,7 +175,7 @@
                 "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
             },
             "require-dev": {
-                "phpcompatibility/php-compatibility": "*"
+                "phpcompatibility/php-compatibility": "^9.0"
             },
             "suggest": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
@@ -192,7 +197,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-07-25T18:10:35+00:00"
+            "time": "2018-11-12T10:13:12+00:00"
         }
     ],
     "aliases": [],

--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -258,7 +258,7 @@ function set_plugin_menu_update_count() {
 	);
 
 	// Ensure the core Plugins menu item is set to the correct index.
-	if ( isset( $menu[ $menu_index ][0] ) && substr( $menu[ $menu_index ][0], 0, 8 ) !== 'Plugins ' ) {
+	if ( isset( $menu[ $menu_index ][0] ) && substr( $menu[ $menu_index ][0], 0, 8 ) !== __( 'Plugins' ) . ' ' ) {
 		return;
 	}
 

--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -15,16 +15,16 @@ function plugin_customizations() {
 	/**
 	 * Stream
 	 */
-	
+
 	/**
 	 * Filters whether to remove stream menu item.
-	 * 
+	 *
 	 * @since 1.1.0
-	 * 
+	 *
 	 * @param bool $tenup_experience_remove_stream_menu_item Whether to remove menu item. Default is true.
 	 */
 	$remove_menu_item = apply_filters( 'tenup_experience_remove_stream_menu_item', true );
-	
+
 	if ( is_plugin_active( 'stream/stream.php' ) && $remove_menu_item ) {
 
 		add_action(
@@ -218,11 +218,28 @@ function set_custom_update_notification( $file, $plugin_data ) {
 	);
 
 	printf(
-		__( 'Theres is a new version of %s available. <a href="%s" target="_blank">View version %s details</a>.' ),
-		wp_kses( $plugin_data['Name'], $plugins_allowedtags ),
-		esc_url( $plugin_data['PluginURI'] ),
-		esc_html( $response->new_version )
+		__( 'There is a new version of %s available. ' ),
+		wp_kses( $plugin_data['Name'], $plugins_allowedtags )
 	);
+
+	$url = $plugin_data['PluginURI'];
+
+	if ( empty( $url ) ) {
+		$url = $plugin_data['url'];
+	}
+
+	if ( empty( $url ) ) {
+		printf(
+			__( 'Version number is %s.' ),
+			esc_html( $response->new_version )
+		);
+	} else {
+		printf(
+			__( '<a href="%s" target="_blank">View version %s details</a>.' ),
+			esc_url( $url ),
+			esc_html( $response->new_version )
+		);
+	}
 
 	print( '</p></div></td></tr>' );
 }
@@ -271,7 +288,7 @@ function set_plugin_menu_update_count() {
  * When the DISALLOW_FILE_MODS is set all plugin counts
  * are set to 0. This sets the plugin update totals so
  * that the counts are displayed in the wp-admin.
- * 
+ *
  * @param array $update_data An array of counts for available plugin, theme, and WordPress updates.
  *
  * @return array $update_data.
@@ -283,8 +300,8 @@ function set_plugin_update_totals( $update_data ) {
 	$update_plugins = get_site_transient( 'update_plugins' );
 	if ( ! empty( $update_plugins->response ) ) {
 		$counts['plugins'] = count( $update_plugins->response );
-		$plugins_title = sprintf( 
-			_n( '%d Plugin Update', '%d Plugin Updates', intval( $counts['plugins'] ) ), 
+		$plugins_title = sprintf(
+			_n( '%d Plugin Update', '%d Plugin Updates', intval( $counts['plugins'] ) ),
 			intval( $counts['plugins'] )
 		);
 		$titles = ! empty( $titles ) ? $titles . ', ' . esc_attr( $plugins_title ) : esc_attr( $plugins_title );
@@ -296,9 +313,9 @@ function set_plugin_update_totals( $update_data ) {
 
 /**
  * Set the upgrade data for the global plugins variable when
- * DISALLOW_FILE_MODS constant is true. 
- * 
- * Leverages the filter 'show_advanced_plugins' which fires 
+ * DISALLOW_FILE_MODS constant is true.
+ *
+ * Leverages the filter 'show_advanced_plugins' which fires
  * before the plugin data is prepared for output.
  */
 function set_global_plugin_data() {

--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -28,9 +28,11 @@ function plugin_customizations() {
 	if ( is_plugin_active( 'stream/stream.php' ) && $remove_menu_item ) {
 
 		add_action(
-			'admin_init', function() {
+			'admin_init',
+			function() {
 				remove_menu_page( 'wp_stream' );
-			}, 11
+			},
+			11
 		);
 	}
 }
@@ -322,10 +324,13 @@ function set_plugin_update_totals( $update_data ) {
  * Set the upgrade data for the global plugins variable when
  * DISALLOW_FILE_MODS constant is true.
  *
- * Leverages the filter 'show_advanced_plugins' which fires
- * before the plugin data is prepared for output.
+ * Leverages two filters in `prepare_items1 of class-wp-plugins-list-table.php
+ * hackishly.
+ *
+ * @param  boolean $value Original filter value.
+ * @return boolean
  */
-function set_global_plugin_data() {
+function set_global_plugin_data( $value ) {
 	global $plugins;
 
 	if ( ! isset( $plugins['all'] ) ) {
@@ -333,6 +338,7 @@ function set_global_plugin_data() {
 	}
 
 	$current = get_site_transient( 'update_plugins' );
+
 	foreach ( (array) $plugins['all'] as $plugin_file => $plugin_data ) {
 		if ( isset( $current->response[ $plugin_file ] ) ) {
 			$plugins['all'][ $plugin_file ]['update'] = true;
@@ -341,6 +347,8 @@ function set_global_plugin_data() {
 	}
 
 	add_filter( 'wp_get_update_data', __NAMESPACE__ . '\set_plugin_update_totals', 10 );
+
+	return $value;
 }
 
 /**
@@ -353,5 +361,6 @@ if ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ) {
 	add_action( 'admin_menu', __NAMESPACE__ . '\set_plugin_menu_update_count', 99 );
 	add_action( 'network_admin_menu', __NAMESPACE__ . '\set_plugin_menu_update_count', 99 );
 	add_filter( 'show_advanced_plugins', __NAMESPACE__ . '\set_global_plugin_data', 10 );
+	add_filter( 'show_network_active_plugins', __NAMESPACE__ . '\set_global_plugin_data', 10 );
 }
 

--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -221,7 +221,7 @@ function set_custom_update_notification( $file, $plugin_data ) {
 		__( 'Theres is a new version of %s available. <a href="%s" target="_blank">View version %s details</a>.' ),
 		wp_kses( $plugin_data['Name'], $plugins_allowedtags ),
 		esc_url( $plugin_data['PluginURI'] ),
-		$response->new_version
+		esc_html( $response->new_version )
 	);
 
 	print( '</p></div></td></tr>' );

--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -87,8 +87,8 @@ add_action( 'install_plugins_tenup', 'display_plugins_table' );
  * Add admin notice
  */
 function add_admin_notice() {
-	add_action( 'admin_notices',  __NAMESPACE__ . '\plugin_install_warning' );
-	add_action( 'network_admin_notices',  __NAMESPACE__ . '\plugin_install_warning' );
+	add_action( 'admin_notices', __NAMESPACE__ . '\plugin_install_warning' );
+	add_action( 'network_admin_notices', __NAMESPACE__ . '\plugin_install_warning' );
 }
 
 /**
@@ -168,7 +168,7 @@ add_action( 'admin_head-plugins.php', __NAMESPACE__ . '\plugin_deactivation_warn
  */
 function set_plugin_update_actions() {
 	$plugins = get_site_transient( 'update_plugins' );
-	if ( isset($plugins->response) && is_array($plugins->response) ) {
+	if ( isset( $plugins->response ) && is_array( $plugins->response ) ) {
 		$plugins = array_keys( $plugins->response );
 		foreach ( $plugins as $plugin_file ) {
 			add_action( "after_plugin_row_$plugin_file", __NAMESPACE__ . '\set_custom_update_notification', 10, 2 );
@@ -189,9 +189,12 @@ function set_custom_update_notification( $file, $plugin_data ) {
 		return false;
 	}
 
-	$response = $current->response[ $file ];
+	$response            = $current->response[ $file ];
 	$plugins_allowedtags = array(
-		'a'       => array( 'href' => array(), 'title' => array() ),
+		'a'       => array(
+			'href'  => array(),
+			'title' => array(),
+		),
 		'abbr'    => array( 'title' => array() ),
 		'acronym' => array( 'title' => array() ),
 		'code'    => array(),
@@ -218,7 +221,7 @@ function set_custom_update_notification( $file, $plugin_data ) {
 	);
 
 	printf(
-		__( 'There is a new version of %s available. ' ),
+		esc_html__( 'There is a new version of %s available. ' ),
 		wp_kses( $plugin_data['Name'], $plugins_allowedtags )
 	);
 
@@ -230,12 +233,12 @@ function set_custom_update_notification( $file, $plugin_data ) {
 
 	if ( empty( $url ) ) {
 		printf(
-			__( 'Version number is %s.' ),
+			esc_html__( 'Version number is %s.' ),
 			esc_html( $response->new_version )
 		);
 	} else {
 		printf(
-			__( '<a href="%s" target="_blank">View version %s details</a>.' ),
+			'<a href="%1$s" target="_blank">' . esc_html__( 'View version %2$s details.' ) . '</a>',
 			esc_url( $url ),
 			esc_html( $response->new_version )
 		);
@@ -259,7 +262,7 @@ function set_plugin_menu_update_count() {
 		$menu_index = 20; // wp-admin network settings
 	}
 
-	$update_data = wp_get_update_data();
+	$update_data    = wp_get_update_data();
 	$update_plugins = get_site_transient( 'update_plugins' );
 	if ( ! empty( $update_plugins->response ) ) {
 		$update_data['counts']['plugins'] = count( $update_plugins->response );
@@ -279,7 +282,7 @@ function set_plugin_menu_update_count() {
 		return;
 	}
 
-	$menu[ $menu_index ][0] = sprintf( __('Plugins %s'), $count );
+	$menu[ $menu_index ][0] = sprintf( __( 'Plugins %s' ), $count );
 }
 
 /**
@@ -300,15 +303,18 @@ function set_plugin_update_totals( $update_data ) {
 	$update_plugins = get_site_transient( 'update_plugins' );
 	if ( ! empty( $update_plugins->response ) ) {
 		$counts['plugins'] = count( $update_plugins->response );
-		$plugins_title = sprintf(
+		$plugins_title     = sprintf(
 			_n( '%d Plugin Update', '%d Plugin Updates', intval( $counts['plugins'] ) ),
 			intval( $counts['plugins'] )
 		);
-		$titles = ! empty( $titles ) ? $titles . ', ' . esc_attr( $plugins_title ) : esc_attr( $plugins_title );
+		$titles            = ! empty( $titles ) ? $titles . ', ' . esc_attr( $plugins_title ) : esc_attr( $plugins_title );
 	}
 	$counts['total'] = $counts['total'] + $counts['plugins'];
 
-	return array( 'counts' => $counts, 'title' => $titles );
+	return array(
+		'counts' => $counts,
+		'title'  => $titles,
+	);
 }
 
 /**
@@ -329,7 +335,7 @@ function set_global_plugin_data() {
 	foreach ( (array) $plugins['all'] as $plugin_file => $plugin_data ) {
 		if ( isset( $current->response[ $plugin_file ] ) ) {
 			$plugins['all'][ $plugin_file ]['update'] = true;
-			$plugins['upgrade'][ $plugin_file ] = $plugins['all'][ $plugin_file ];
+			$plugins['upgrade'][ $plugin_file ]       = $plugins['all'][ $plugin_file ];
 		}
 	}
 

--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -271,6 +271,7 @@ function set_plugin_menu_update_count() {
 	if ( 1 > $update_data['counts']['plugins'] ) {
 		return;
 	}
+
 	$count = sprintf(
 		'<span class="update-plugins count-%d"><span class="plugin-count">%d</span></span>',
 		esc_attr( $update_data['counts']['plugins'] ),
@@ -278,7 +279,7 @@ function set_plugin_menu_update_count() {
 	);
 
 	// Ensure the core Plugins menu item is set to the correct index.
-	if ( isset( $menu[ $menu_index ][0] ) && substr( $menu[ $menu_index ][0], 0, 8 ) !== __( 'Plugins' ) . ' ' ) {
+	if ( isset( $menu[ $menu_index ][0] ) && ! preg_match( '#^' . esc_html__( 'Plugins' ) . '#i', $menu[ $menu_index ][0] ) ) {
 		return;
 	}
 

--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -257,6 +257,11 @@ function set_plugin_menu_update_count() {
 		number_format_i18n( $update_data['counts']['plugins'] )
 	);
 
+	// Ensure the core Plugins menu item is set to the correct index.
+	if ( isset( $menu[ $menu_index ][0] ) && substr( $menu[ $menu_index ][0], 0, 8 ) !== 'Plugins ' ) {
+		return;
+	}
+
 	$menu[ $menu_index ][0] = sprintf( __('Plugins %s'), $count );
 }
 


### PR DESCRIPTION
The DISALLOW_FILE_MODS constant prevents plugins and themes from being updated via the WordPress admin. This constant is used often when we do not want to risk plugins mistakenly being updated on projects without first testing it out. We typically add/remove plugins and update plugin versions using composer when using DISALLOW_FILE_MODS, this ensures that there is a workflow which involves an engineer first testing an update before deploying it to production.

One of the downsides of using this approach is that there is no notifications in the WordPress admin indicating that an update has been released. This often results in major releases and even security updates being missed.

This update allows the plugin update count to be added to the WordPress admin Plugin menu item and the update notifications are added on the plugin list page. There is still no way for the plugins to be updated via the WordPress admin, however this should help ensure that we are aware of plugin updates.

![update-notifications](https://user-images.githubusercontent.com/9355549/45708985-1c9d9780-bb83-11e8-8515-0ae1262549cd.png)
![plugin-updates](https://user-images.githubusercontent.com/9355549/45708986-1d362e00-bb83-11e8-845c-46f1ffea77f1.png)
