### PR TITLE
Feature/prevent weak password

### DIFF
--- a/10up-experience.php
+++ b/10up-experience.php
@@ -19,6 +19,7 @@ require_once __DIR__ . '/includes/admin-bar.php';
 require_once __DIR__ . '/includes/admin-pages.php';
 require_once __DIR__ . '/includes/plugins.php';
 require_once __DIR__ . '/includes/rest-api.php';
+require_once __DIR__ . '/includes/authentication.php';
 
 require_once __DIR__ . '/vendor/plugin-update-checker/plugin-update-checker.php';
 

--- a/includes/authentication.php
+++ b/includes/authentication.php
@@ -18,7 +18,7 @@ namespace tenup;
  */
 function prevent_weak_password_auth( $user, $username, $password ) {
 	if ( in_array( $password, weak_passwords() ) ) {
-		return new \WP_Error( 'Auth Error', __( "Please reset your password.", "tenup" ) );
+		return new \WP_Error( 'Auth Error', __( "Please reset your password by clicking on the 'Lost your Password?' link below.", "tenup" ) );
 	}
 
 	return $user;

--- a/includes/authentication.php
+++ b/includes/authentication.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Authentication functionality
+ *
+ * @package  10up-experience
+ */
+
+namespace tenup;
+
+/**
+ * Prevent users from authenticating if they are using a weak password
+ *
+ * @param $user
+ * @param $username
+ * @param $password
+ *
+ * @return \WP_User|\WP_Error
+ */
+function prevent_weak_password_auth( $user, $username, $password ) {
+	if ( in_array( $password, weak_passwords() ) ) {
+		return new \WP_Error( 'Auth Error', __( "Please reset your password.", "tenup" ) );
+	}
+
+	return $user;
+}
+
+add_filter( 'authenticate', __NAMESPACE__ . '\prevent_weak_password_auth', 30, 3 );
+
+/**
+ * List of the most popular weak passwords
+ *
+ * @return array
+ */
+function weak_passwords() {
+	return array(
+		'123456',
+		'Password',
+		'password',
+		'12345678',
+		'qwerty',
+		'12345',
+		'123456789',
+		'letmein',
+		'1234567',
+		'football',
+		'iloveyou',
+		'admin',
+		'welcome',
+		'monkey',
+		'login',
+		'abc123',
+		'starwars',
+		'123123',
+		'dragon',
+		'passw0rd',
+		'master',
+		'hello',
+		'freedom',
+		'whatever',
+		'qazwsx',
+		'trustno1',
+		'654321',
+		'jordan23',
+		'harley',
+		'password1',
+		'1234',
+		'robert',
+		'matthew',
+		'jordan',
+		'asshole',
+		'daniel',
+	);
+}


### PR DESCRIPTION
This feature prevents users from authenticating if they currently have a weak password. A weak password might have been set by a user or came over with a migration. If one of the weak passwords from our list is used the user is prompted to reset their password. 

![screen shot 2018-09-28 at 9 48 23 am](https://user-images.githubusercontent.com/1428016/46212900-294d8880-c305-11e8-9d56-f1df5ceb7f92.png)

cc: @tlovett1 
