### PR TITLE
Feature/disable canonicals

### DIFF
--- a/10up-experience.php
+++ b/10up-experience.php
@@ -19,6 +19,7 @@ require_once __DIR__ . '/includes/admin-bar.php';
 require_once __DIR__ . '/includes/admin-pages.php';
 require_once __DIR__ . '/includes/plugins.php';
 require_once __DIR__ . '/includes/rest-api.php';
+require_once __DIR__ . '/includes/cononical-redirects.php';
 
 require_once __DIR__ . '/vendor/plugin-update-checker/plugin-update-checker.php';
 

--- a/includes/cononical-redirects.php
+++ b/includes/cononical-redirects.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * WordPress admin and login shorthand redirects
+ *
+ * @package  10up-experience
+ */
+
+namespace tenup;
+
+remove_action( 'template_redirect', 'wp_redirect_admin_locations', 1000 );

--- a/includes/cononical-redirects.php
+++ b/includes/cononical-redirects.php
@@ -7,4 +7,8 @@
 
 namespace tenup;
 
+/**
+ * Remove the default shorthand redirects WordPress core implements like
+ * /login, /admin, and / dashboard.
+ */
 remove_action( 'template_redirect', 'wp_redirect_admin_locations', 1000 );


### PR DESCRIPTION
WordPress core auto redirects users to the login or admin if they enter a shorthand URL. This removes this redirect completly.

https://github.com/WordPress/WordPress/blob/56c162fbc9867f923862f64f1b4570d885f1ff03/wp-includes/canonical.php#L709

cc: @tlovett1 
