### PR TITLE
Fix/remove menu page warning

### DIFF
--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -29,6 +29,11 @@ function plugin_customizations() {
 
 		add_action(
 			'admin_init', function() {
+				// Don't proceed if doing admin ajax as "remove_menu_page" produces a Invalid argument supplied for foreach() warning
+				if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+					return;
+				}
+
 				remove_menu_page( 'wp_stream' );
 			}, 11
 		);


### PR DESCRIPTION
This fixes the PHP warning reported in issue #24 where the following warning was produced when doing an admin ajax call. 

`E_WARNING: Invalid argument supplied for foreach()
in remove_menu_page called at wp-content/plugins/10up-experience/includes/plugins.php (32)`

I tested this by having both the Stream and 10up Experience plugin enabled at the same time while having WP_DEBUG and WP_DEBUG_LOG set to true and updating a widget to produce an admin ajax request. 