### PR TITLE
Introduce failsafe procedures for required options

### DIFF
--- a/10up-experience.php
+++ b/10up-experience.php
@@ -22,6 +22,7 @@ require_once __DIR__ . '/includes/rest-api.php';
 require_once __DIR__ . '/includes/gutenberg.php';
 require_once __DIR__ . '/includes/authors.php';
 require_once __DIR__ . '/includes/authentication.php';
+require_once __DIR__ . '/includes/option-failsafes.php';
 
 require_once __DIR__ . '/vendor/plugin-update-checker/plugin-update-checker.php';
 

--- a/includes/option-failsafes.php
+++ b/includes/option-failsafes.php
@@ -28,7 +28,7 @@ function required_option_failsafes() {
 	 *
 	 * @param array $required_options An array of required option keys.
 	 */
-	$required_options = apply_filters( 'tenup_experience_required_options', [ 'siteurl', 'home', 'wp_user_roles' ] );
+	$required_options = apply_filters( 'tenup_experience_required_options', [ 'siteurl', 'home', 'wp_user_roles', 'rewrite_rules' ] );
 
 	foreach ( $required_options as $option ) {
 		add_filter( "default_option_{$option}", __NAMESPACE__ . '\\require_option_failsafe', 10, 3 );

--- a/includes/option-failsafes.php
+++ b/includes/option-failsafes.php
@@ -71,6 +71,9 @@ function require_option_failsafe( $default, $option, $passed_default ) {
 		return $default;
 	}
 
+	// Record current time as last checked time.
+	wp_cache_set( "option_last_checked_{$option}", time(), 'options' );
+
 	// Remove the required option from notoptions array.
 	$notoptions = wp_cache_get( 'notoptions', 'options' );
 	if ( is_array( $notoptions ) && isset( $notoptions[ $option ] ) ) {
@@ -85,9 +88,6 @@ function require_option_failsafe( $default, $option, $passed_default ) {
 		wp_cache_set( 'alloptions', $alloptions, 'options' );
 	}
 	wp_cache_delete( $option, 'options' );
-
-	// Record current time as last checked time.
-	wp_cache_set( "option_last_checked_{$option}", time(), 'options' );
 
 	// Recheck for the option as it now will not be in the "notoptions" array.
 	return get_option( $option );

--- a/includes/option-failsafes.php
+++ b/includes/option-failsafes.php
@@ -73,15 +73,17 @@ function require_option_failsafe( $default, $option, $passed_default ) {
 
 	// Remove the required option from notoptions array.
 	$notoptions = wp_cache_get( 'notoptions', 'options' );
-	if ( is_array( $notoptions ) ) {
+	if ( is_array( $notoptions ) && isset( $notoptions[ $option ] ) ) {
 		unset( $notoptions[ $option ] );
 		wp_cache_set( 'notoptions', $notoptions, 'options' );
 	}
 
 	// Purge other caches where we might have a bad value.
 	$alloptions = wp_load_alloptions();
-	unset( $alloptions[ $option ] );
-	wp_cache_set( 'alloptions', $alloptions, 'options' );
+	if ( isset( $alloptions[ $option ] ) ) {
+		unset( $alloptions[ $option ] );
+		wp_cache_set( 'alloptions', $alloptions, 'options' );
+	}
 	wp_cache_delete( $option, 'options' );
 
 	// Record current time as last checked time.

--- a/includes/option-failsafes.php
+++ b/includes/option-failsafes.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Required option failsafes
+ *
+ * @package  10up-experience
+ */
+
+namespace tenup;
+
+/**
+ * Ensures a list of required options have failsafes in place.
+ *
+ * In the event that WordPress is unable to establish momentary connection with the
+ * database, a required option may unintentionally end up in the notoptions cache. Once
+ * an option is in the notoptions cache, it will not be read from the database on any
+ * future requests for that option.  This has the potential to bring down a site if a
+ * critical option is not checked and returns false by default.
+ *
+ * This function adds default option filters on required options that ensure they will
+ * not exist in the notoptions cache for long enough to bring a site down for more than
+ * a few seconds.
+ *
+ * @return void
+ */
+function required_option_failsafes() {
+	/**
+	 * Filters the array of required options.
+	 *
+	 * @param array $required_options An array of required option keys.
+	 */
+	$required_options = apply_filters( 'tenup_experience_required_options', [ 'siteurl', 'home', 'wp_user_roles' ] );
+
+	foreach ( $required_options as $option ) {
+		add_filter( "default_option_{$option}", __NAMESPACE__ . '\\require_option_failsafe', 10, 3 );
+	}
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\\required_option_failsafes' );
+
+/**
+ * Establish a failsafe for a required option.
+ *
+ * If WordPress is unable to retrieve a value for a required option, this filter
+ * will ensure that the required option does not persist in the notoptions cache
+ * for more than a period defined by the max age, by default, 10 seconds.
+ *
+ * @param mixed  $default        The default value.
+ * @param string $option         The option name.
+ * @param bool   $passed_default Whether the default was passed as a paremeter to get_option.
+ * @return mixed
+ */
+function require_option_failsafe( $default, $option, $passed_default ) {
+	// If we were explicitly passed a default, return the passed default value.
+	if ( $passed_default ) {
+		return $default;
+	}
+
+	// Did we look up this value recently?
+	$last_lookup = (int) wp_cache_get( "option_last_checked_{$option}", 'options' );
+	$time_since  = time() - $last_lookup;
+
+	/**
+	 * Filters the maximum age that a required option can be stored in the notoptions cache.
+	 *
+	 * @param int    $max_age The max age in seconds, default 10s.
+	 * @param string $option  The name of the option that is being checked.
+	 */
+	$max_age = apply_filters( 'tenup_experience_required_option_max_age', 10, $option );
+
+	// If we checked less than x seconds ago, return whatever we have.
+	if ( $max_age >= $time_since ) {
+		return $default;
+	}
+
+	// Remove the required option from notoptions array.
+	$notoptions = wp_cache_get( 'notoptions', 'options' );
+	if ( is_array( $notoptions ) ) {
+		unset( $notoptions[ $option ] );
+		wp_cache_set( 'notoptions', $notoptions, 'options' );
+	}
+
+	// Record current time as last checked time.
+	wp_cache_set( "option_last_checked_{$option}", time(), 'options' );
+
+	// Recheck for the option as it now will not be in the "notoptions" array.
+	return get_option( $option );
+}

--- a/includes/option-failsafes.php
+++ b/includes/option-failsafes.php
@@ -78,6 +78,12 @@ function require_option_failsafe( $default, $option, $passed_default ) {
 		wp_cache_set( 'notoptions', $notoptions, 'options' );
 	}
 
+	// Purge other caches where we might have a bad value.
+	$alloptions = wp_load_alloptions();
+	unset( $alloptions[ $option ] );
+	wp_cache_set( 'alloptions', $alloptions, 'options' );
+	wp_cache_delete( $option, 'options' );
+
 	// Record current time as last checked time.
 	wp_cache_set( "option_last_checked_{$option}", time(), 'options' );
 


### PR DESCRIPTION
In the event of a momentary database disconnection with WordPress, required options can be cached in `notoptions` and never re-checked upon database reconnection.  This pull request introduces filters that establish a failsafe procedure whereby required options can only exist in the `notoptions` cache for a maximum period, by default, 10 seconds.