### PR TITLE
Release 1.5

### DIFF
--- a/10up-experience.php
+++ b/10up-experience.php
@@ -12,7 +12,7 @@
  * @package 10up-experience
  */
 
-define( 'TENUP_EXPERIENCE_VERSION', '1.4' );
+define( 'TENUP_EXPERIENCE_VERSION', '1.5' );
 
 require_once __DIR__ . '/includes/admin.php';
 require_once __DIR__ . '/includes/admin-bar.php';

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "10up/10up-experience",
   "description": "The 10up Experience plugin configures WordPress to better protect and inform clients, aligned to 10up's best practices",
-  "version": "1.4",
+  "version": "1.5",
   "minimum-stability": "dev",
   "type": "wordpress-plugin",
   "keywords": [


### PR DESCRIPTION
Changes:

- Adds failsafes if temporary loss of database connection causes required options to be stored in the `notoptions` cache.