### PR TITLE
Remove Option Failsafes

### DIFF
--- a/10up-experience.php
+++ b/10up-experience.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: 10up Experience
  * Description: The 10up Experience plugin configures WordPress to better protect and inform clients, aligned to 10up’s best practices.
- * Version:     1.6
+ * Version:     1.7
  * Author:      10up
  * Author URI:  https://10up.com
  * License:     GPLv2 or later
@@ -12,7 +12,7 @@
  * @package 10up-experience
  */
 
-define( 'TENUP_EXPERIENCE_VERSION', '1.6' );
+define( 'TENUP_EXPERIENCE_VERSION', '1.7' );
 
 require_once __DIR__ . '/includes/admin.php';
 require_once __DIR__ . '/includes/admin-bar.php';
@@ -22,7 +22,6 @@ require_once __DIR__ . '/includes/rest-api.php';
 require_once __DIR__ . '/includes/gutenberg.php';
 require_once __DIR__ . '/includes/authors.php';
 require_once __DIR__ . '/includes/authentication.php';
-require_once __DIR__ . '/includes/option-failsafes.php';
 require_once __DIR__ . '/includes/password-protection.php';
 
 require_once __DIR__ . '/vendor/yahnis-elsts/plugin-update-checker/plugin-update-checker.php';

--- a/includes/option-failsafes.php
+++ b/includes/option-failsafes.php
@@ -2,6 +2,10 @@
 /**
  * Required option failsafes
  *
+ * @internal This feature has been removed as of version 1.7, as we reevaluate our approach
+ * to implementing safeguards on required options. The code here is preserved as a work
+ * in progress, but is not loaded during plugin execution.
+ *
  * @package  10up-experience
  */
 


### PR DESCRIPTION
### Description of the Change

Removes option failsafe feature from execution.  Indicates approach to feature is being reevaluated.

### Benefits

Fixes #54 

### Possible Drawbacks

Re-opens possibility of database connection errors storing `siteurl` and `home` in the `$notoptions` cache.  Risk of bringing down a site.

### Applicable Issues

#54 

### Changelog Entry

- Removes required options feature while approach is being reevaluated.
