### PR TITLE
Feature/system client debugging

### DIFF
--- a/10up-experience.php
+++ b/10up-experience.php
@@ -27,6 +27,7 @@ require_once __DIR__ . '/includes/authors.php';
 require_once __DIR__ . '/includes/authentication.php';
 require_once __DIR__ . '/includes/password-protection.php';
 require_once __DIR__ . '/includes/support-monitor.php';
+require_once __DIR__ . '/includes/support-monitor-debug.php';
 
 require_once __DIR__ . '/vendor/yahnis-elsts/plugin-update-checker/plugin-update-checker.php';
 

--- a/10up-experience.php
+++ b/10up-experience.php
@@ -12,8 +12,11 @@
  * @package 10up-experience
  */
 
+namespace TenUpExperience;
+
 define( 'TENUP_EXPERIENCE_VERSION', '1.6.1' );
 
+require_once __DIR__ . '/includes/utils.php';
 require_once __DIR__ . '/includes/admin.php';
 require_once __DIR__ . '/includes/admin-bar.php';
 require_once __DIR__ . '/includes/admin-pages.php';
@@ -23,10 +26,11 @@ require_once __DIR__ . '/includes/gutenberg.php';
 require_once __DIR__ . '/includes/authors.php';
 require_once __DIR__ . '/includes/authentication.php';
 require_once __DIR__ . '/includes/password-protection.php';
+require_once __DIR__ . '/includes/support-monitor.php';
 
 require_once __DIR__ . '/vendor/yahnis-elsts/plugin-update-checker/plugin-update-checker.php';
 
-$tenup_plugin_updater = Puc_v4_Factory::buildUpdateChecker(
+$tenup_plugin_updater = \Puc_v4_Factory::buildUpdateChecker(
 	'https://github.com/10up/10up-experience/',
 	__FILE__,
 	'10up-experience'
@@ -38,10 +42,27 @@ if ( defined( 'TENUP_EXPERIENCE_GITHUB_KEY' ) ) {
 
 $tenup_plugin_updater->addResultFilter(
 	function( $plugin_info, $http_response = null ) {
-			$plugin_info->icons = array(
-				'svg' => plugins_url( '/assets/img/tenup.svg', __FILE__ ),
-			);
+		$plugin_info->icons = array(
+			'svg' => plugins_url( '/assets/img/tenup.svg', __FILE__ ),
+		);
 
-			return $plugin_info;
+		return $plugin_info;
 	}
 );
+
+// Define a constant if we're network activated to allow plugin to respond accordingly.
+$network_activated = Utils\is_network_activated( plugin_basename( __FILE__ ) );
+
+define( 'TENUP_EXPERIENCE_IS_NETWORK', (bool) $network_activated );
+
+Admin\setup();
+AdminBar\setup();
+AdminPages\setup();
+Plugins\setup();
+RestAPI\setup();
+Gutenberg\setup();
+Authors\setup();
+Authentication\setup();
+PasswordProtection\setup();
+SupportMonitor\setup();
+

--- a/includes/admin-bar.php
+++ b/includes/admin-bar.php
@@ -5,7 +5,16 @@
  * @package  10up-experience
  */
 
-namespace tenup;
+namespace TenUpExperience\AdminBar;
+
+/**
+ * Setup module
+ *
+ * @since 1.7
+ */
+function setup() {
+	add_action( 'admin_bar_menu', __NAMESPACE__ . '\add_about_menu', 11 );
+}
 
 /**
  * Let's setup our 10up menu in the toolbar
@@ -39,4 +48,3 @@ function add_about_menu( $wp_admin_bar ) {
 	}
 
 }
-add_action( 'admin_bar_menu', __NAMESPACE__ . '\add_about_menu', 11 );

--- a/includes/admin-pages.php
+++ b/includes/admin-pages.php
@@ -5,7 +5,17 @@
  * @package  10up-experience
  */
 
-namespace tenup;
+namespace TenUpExperience\AdminPages;
+
+/**
+ * Setup module
+ *
+ * @since 1.7
+ */
+function setup() {
+	add_action( 'admin_menu', __NAMESPACE__ . '\register_admin_pages' );
+	add_filter( 'admin_title', __NAMESPACE__ . '\admin_title_fix', 10, 2 );
+}
 
 /**
  * Register admin pages with output callbacks
@@ -13,7 +23,6 @@ namespace tenup;
 function register_admin_pages() {
 	add_submenu_page( null, esc_html__( 'About 10up', 'tenup' ), esc_html__( 'About 10up', 'tenup' ), 'edit_posts', '10up-about', __NAMESPACE__ . '\main_screen' );
 }
-add_action( 'admin_menu', __NAMESPACE__ . '\register_admin_pages' );
 
 /**
  * Ensure our admin pages get a proper title.
@@ -40,7 +49,6 @@ function admin_title_fix( $admin_title, $title ) {
 
 	return $admin_title;
 }
-add_filter( 'admin_title', __NAMESPACE__ . '\admin_title_fix', 10, 2 );
 
 /**
  * Output about screens

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -5,7 +5,18 @@
  * @package  10up-experience
  */
 
-namespace tenup;
+namespace TenUpExperience\Admin;
+
+/**
+ * Setup module
+ *
+ * @since 1.7
+ */
+function setup() {
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\admin_enqueue_scripts' );
+	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
+	add_filter( 'admin_footer_text', __NAMESPACE__ . '\filter_admin_footer_text' );
+}
 
 /**
  * Disable plugin/theme editor
@@ -26,7 +37,6 @@ function admin_enqueue_scripts() {
 		wp_enqueue_style( '10up-about', plugins_url( '/assets/css/tenup-pages.css', dirname( __FILE__ ) ), array(), TENUP_EXPERIENCE_VERSION );
 	}
 }
-add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\admin_enqueue_scripts' );
 
 /**
  * Enqueue front end scripts
@@ -37,7 +47,6 @@ function enqueue_scripts() {
 		wp_enqueue_style( '10up-admin', plugins_url( '/assets/css/admin.css', dirname( __FILE__ ) ), array(), TENUP_EXPERIENCE_VERSION );
 	}
 }
-add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
 
 /**
  * Filter admin footer text "Thank you for creating..."
@@ -48,4 +57,3 @@ function filter_admin_footer_text() {
 	$new_text = sprintf( __( 'Thank you for creating with <a href="https://wordpress.org">WordPress</a> and <a href="http://10up.com">10up</a>.', 'tenup' ) );
 	return $new_text;
 }
-add_filter( 'admin_footer_text', __NAMESPACE__ . '\filter_admin_footer_text' );

--- a/includes/authentication.php
+++ b/includes/authentication.php
@@ -5,7 +5,16 @@
  * @package  10up-experience
  */
 
-namespace tenup;
+namespace TenUpExperience\Authentication;
+
+/**
+ * Setup module
+ *
+ * @since 1.7
+ */
+function setup() {
+	add_filter( 'authenticate', __NAMESPACE__ . '\prevent_weak_password_auth', 30, 3 );
+}
 
 /**
  * Prevent users from authenticating if they are using a weak password
@@ -35,8 +44,6 @@ function prevent_weak_password_auth( $user, $username, $password ) {
 
 	return $user;
 }
-
-add_filter( 'authenticate', __NAMESPACE__ . '\prevent_weak_password_auth', 30, 3 );
 
 /**
  * List of popular weak passwords

--- a/includes/authors.php
+++ b/includes/authors.php
@@ -5,7 +5,16 @@
  * @package  10up-experience
  */
 
-namespace tenup;
+namespace TenUpExperience\Authors;
+
+/**
+ * Setup module
+ *
+ * @since 1.7
+ */
+function setup() {
+	add_action( 'wp', __NAMESPACE__ . '\\maybe_disable_author_archive' );
+}
 
 /**
  * Check to see if author archive page should be disabled for 10up user accounts
@@ -54,5 +63,3 @@ function maybe_disable_author_archive() {
 		exit();
 	}
 }
-
-add_action( 'wp', __NAMESPACE__ . '\\maybe_disable_author_archive' );

--- a/includes/gutenberg.php
+++ b/includes/gutenberg.php
@@ -5,7 +5,17 @@
  * @package  10up-experience
  */
 
-namespace tenup;
+namespace TenUpExperience\Gutenberg;
+
+/**
+ * Setup module
+ *
+ * @since 1.7
+ */
+function setup() {
+	add_action( 'admin_init', __NAMESPACE__ . '\disable_gutenberg_editor_setting' );
+	add_action( 'admin_init', __NAMESPACE__ . '\maybe_disable_gutenberg_editor' );
+}
 
 /**
  * Register 10up Gutenberg setting.
@@ -30,8 +40,6 @@ function disable_gutenberg_editor_setting() {
 		)
 	);
 }
-
-add_action( 'admin_init', __NAMESPACE__ . '\disable_gutenberg_editor_setting' );
 
 /**
  * Display UI for 10up custom Gutenberg settings.
@@ -77,5 +85,3 @@ function maybe_disable_gutenberg_editor() {
 	// Gutenberg plugin
 	add_filter( 'gutenberg_can_edit_post', '__return_false' );
 }
-
-add_action( 'admin_init', __NAMESPACE__ . '\maybe_disable_gutenberg_editor' );

--- a/includes/option-failsafes.php
+++ b/includes/option-failsafes.php
@@ -9,7 +9,16 @@
  * @package  10up-experience
  */
 
-namespace tenup;
+namespace TenUpExperience\OptionFailsafes;
+
+/**
+ * Setup module
+ *
+ * @since 1.7
+ */
+function setup() {
+	add_action( 'plugins_loaded', __NAMESPACE__ . '\\required_option_failsafes' );
+}
 
 /**
  * Ensures a list of required options have failsafes in place.
@@ -38,7 +47,6 @@ function required_option_failsafes() {
 		add_filter( "default_option_{$option}", __NAMESPACE__ . '\\require_option_failsafe', 10, 3 );
 	}
 }
-add_action( 'plugins_loaded', __NAMESPACE__ . '\\required_option_failsafes' );
 
 /**
  * Establish a failsafe for a required option.

--- a/includes/password-protection.php
+++ b/includes/password-protection.php
@@ -5,7 +5,17 @@
  * @package  10up-experience
  */
 
-namespace tenup;
+namespace TenUpExperience\PasswordProtection;
+
+/**
+ * Setup module
+ *
+ * @since 1.7
+ */
+function setup() {
+	add_action( 'admin_init', __NAMESPACE__ . '\password_protection_setting' );
+	add_action( 'admin_print_footer_scripts', __NAMESPACE__ . '\print_admin_css' );
+}
 
 /**
  * Register setting.
@@ -30,8 +40,6 @@ function password_protection_setting() {
 		)
 	);
 }
-
-add_action( 'admin_init', __NAMESPACE__ . '\password_protection_setting' );
 
 /**
  * Display UI the setting.
@@ -83,5 +91,3 @@ function print_admin_css() {
 	</style>
 	<?php
 }
-
-add_action( 'admin_print_footer_scripts', __NAMESPACE__ . '\print_admin_css' );

--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -5,7 +5,45 @@
  * @package  10up-experience
  */
 
-namespace tenup;
+namespace TenUpExperience\Plugins;
+
+/**
+ * Setup module
+ *
+ * @since 1.7
+ */
+function setup() {
+	add_action( 'admin_init', __NAMESPACE__ . '\plugin_customizations' );
+	add_filter( 'install_plugins_tabs', __NAMESPACE__ . '\tenup_plugin_install_link' );
+	add_filter( 'install_plugins_table_api_args_tenup', __NAMESPACE__ . '\filter_install_plugin_args' );
+
+	/**
+	 * Setup 10up suggested plugin display table
+	 */
+	add_action( 'install_plugins_tenup', 'display_plugins_table' );
+
+	add_action( 'install_plugins_pre_featured', __NAMESPACE__ . '\add_admin_notice' );
+	add_action( 'install_plugins_pre_popular', __NAMESPACE__ . '\add_admin_notice' );
+	add_action( 'install_plugins_pre_favorites', __NAMESPACE__ . '\add_admin_notice' );
+	add_action( 'install_plugins_pre_beta', __NAMESPACE__ . '\add_admin_notice' );
+	add_action( 'install_plugins_pre_search', __NAMESPACE__ . '\add_admin_notice' );
+	add_action( 'install_plugins_pre_dashboard', __NAMESPACE__ . '\add_admin_notice' );
+	add_filter( 'plugin_row_meta', __NAMESPACE__ . '\plugin_meta', 100, 4 );
+	add_action( 'admin_head-plugins.php', __NAMESPACE__ . '\plugin_deactivation_warning' );
+
+	/**
+	 * If we are disallowing plugin updates using the DISALLOW_FILE_MODS
+	 * constant this will still allow the plugin update notification to
+	 * show in the wp-admin plugins page.
+	 */
+	if ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ) {
+		add_action( 'load-plugins.php', __NAMESPACE__ . '\set_plugin_update_actions', 21 );
+		add_action( 'admin_menu', __NAMESPACE__ . '\set_plugin_menu_update_count', 99 );
+		add_action( 'network_admin_menu', __NAMESPACE__ . '\set_plugin_menu_update_count', 99 );
+		add_filter( 'show_advanced_plugins', __NAMESPACE__ . '\set_global_plugin_data', 10 );
+		add_filter( 'show_network_active_plugins', __NAMESPACE__ . '\set_global_plugin_data', 10 );
+	}
+}
 
 /**
  * Start plugin customizations
@@ -41,7 +79,6 @@ function plugin_customizations() {
 		);
 	}
 }
-add_action( 'admin_init', __NAMESPACE__ . '\plugin_customizations' );
 
 /**
  * Add 10up suggested tab to plugins install screen
@@ -60,7 +97,6 @@ function tenup_plugin_install_link( $tabs ) {
 
 	return $new_tabs;
 }
-add_filter( 'install_plugins_tabs', __NAMESPACE__ . '\tenup_plugin_install_link' );
 
 /**
  * Filter the arguments passed to plugins_api() for 10up suggested page
@@ -83,12 +119,6 @@ function filter_install_plugin_args( $args ) {
 
 	return $args;
 }
-add_filter( 'install_plugins_table_api_args_tenup', __NAMESPACE__ . '\filter_install_plugin_args' );
-
-/**
- * Setup 10up suggested plugin display table
- */
-add_action( 'install_plugins_tenup', 'display_plugins_table' );
 
 /**
  * Add admin notice
@@ -118,12 +148,7 @@ function plugin_install_warning() {
 	</div>
 	<?php
 }
-add_action( 'install_plugins_pre_featured', __NAMESPACE__ . '\add_admin_notice' );
-add_action( 'install_plugins_pre_popular', __NAMESPACE__ . '\add_admin_notice' );
-add_action( 'install_plugins_pre_favorites', __NAMESPACE__ . '\add_admin_notice' );
-add_action( 'install_plugins_pre_beta', __NAMESPACE__ . '\add_admin_notice' );
-add_action( 'install_plugins_pre_search', __NAMESPACE__ . '\add_admin_notice' );
-add_action( 'install_plugins_pre_dashboard', __NAMESPACE__ . '\add_admin_notice' );
+
 /**
  * Add a "learn more" link to the plugin row that points to the admin page.
  *
@@ -144,7 +169,6 @@ function plugin_meta( $plugin_meta, $plugin_file, $plugin_data, $status ) {
 	$plugin_meta[] = '<a href="' . esc_url( admin_url( 'admin.php?page=10up-about' ) ) . '">' . esc_html__( 'Learn more', 'tenup' ) . '</a>';
 	return $plugin_meta;
 }
-add_filter( 'plugin_row_meta', __NAMESPACE__ . '\plugin_meta', 100, 4 );
 
 /**
  * Inject a small script for an AYS on plugin deactivation.
@@ -165,7 +189,6 @@ jQuery( document ).ready( function( $ ) {
 </script>
 	<?php
 }
-add_action( 'admin_head-plugins.php', __NAMESPACE__ . '\plugin_deactivation_warning' );
 
 
 /**
@@ -362,18 +385,5 @@ function set_global_plugin_data( $value ) {
 	add_filter( 'wp_get_update_data', __NAMESPACE__ . '\set_plugin_update_totals', 10 );
 
 	return $value;
-}
-
-/**
- * If we are disallowing plugin updates using the DISALLOW_FILE_MODS
- * constant this will still allow the plugin update notification to
- * show in the wp-admin plugins page.
- */
-if ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ) {
-	add_action( 'load-plugins.php', __NAMESPACE__ . '\set_plugin_update_actions', 21 );
-	add_action( 'admin_menu', __NAMESPACE__ . '\set_plugin_menu_update_count', 99 );
-	add_action( 'network_admin_menu', __NAMESPACE__ . '\set_plugin_menu_update_count', 99 );
-	add_filter( 'show_advanced_plugins', __NAMESPACE__ . '\set_global_plugin_data', 10 );
-	add_filter( 'show_network_active_plugins', __NAMESPACE__ . '\set_global_plugin_data', 10 );
 }
 

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -5,7 +5,19 @@
  * @package  10up-experience
  */
 
-namespace tenup;
+namespace TenUpExperience\RestAPI;
+
+/**
+ * Setup module
+ *
+ * @since 1.7
+ */
+function setup() {
+	// Make sure this runs somewhat late but before core's cookie auth at 100
+	add_filter( 'rest_authentication_errors', __NAMESPACE__ . '\restrict_rest_api', 99 );
+	add_filter( 'rest_endpoints', __NAMESPACE__ . '\restrict_user_endpoints' );
+	add_action( 'admin_init', __NAMESPACE__ . '\restrict_rest_api_setting' );
+}
 
 /**
  * Return a 403 status and corresponding error for unauthed REST API access.
@@ -29,8 +41,6 @@ function restrict_rest_api( $result ) {
 
 	return $result;
 }
-// Make sure this runs somewhat late but before core's cookie auth at 100
-add_filter( 'rest_authentication_errors', __NAMESPACE__ . '\restrict_rest_api', 99 );
 
 /**
  * Remove user endpoints for unauthed users.
@@ -57,7 +67,6 @@ function restrict_user_endpoints( $endpoints ) {
 
 	return $endpoints;
 }
-add_filter( 'rest_endpoints', __NAMESPACE__ . '\restrict_user_endpoints' );
 
 /**
  * Register restrict REST API setting.
@@ -77,7 +86,6 @@ function restrict_rest_api_setting() {
 	register_setting( 'reading', 'tenup_restrict_rest_api', $settings_args );
 	add_settings_field( 'tenup_restrict_rest_api', __( 'REST API Availability', 'tenup' ), __NAMESPACE__ . '\restrict_rest_api_ui', 'reading' );
 }
-add_action( 'admin_init', __NAMESPACE__ . '\restrict_rest_api_setting' );
 
 /**
  * Display UI for restrict REST API setting.

--- a/includes/support-monitor-debug.php
+++ b/includes/support-monitor-debug.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * 10up suppport monitor debugger. This can be enabled by setting the following in wp-config.php:
+ * define( 'SUPPORT_MONITOR_DEBUG', true );
+ *
+ * @since  1.7
+ * @package 10up-experience
+ */
+
+namespace TenUpExperience\SupportMonitor\Debug;
+
+/**
+ * Support Monitor Log custom post type slug
+ */
+const CPT_SLUG = 'support_mon_debug';
+
+/**
+ * Setup module
+ *
+ * @since 1.7
+ */
+function setup() {
+
+	// No need to run setup functions if debug is disabled
+	if ( ! is_debug_enabled() ) {
+		return;
+	}
+
+	add_action( 'init',       __NAMESPACE__ . '\register_debug_cpt' );
+	add_action( 'admin_menu', __NAMESPACE__ . '\register_menu' );
+
+}
+
+/**
+ * Register the post monitor debugger post type
+ *
+ * @return void
+ */
+function register_debug_cpt() {
+
+	$args = array(
+		'public'             => false,
+		'publicly_queryable' => false,
+		'show_in_rest'       => false,
+		'show_ui'            => true,
+		'show_in_menu'       => false,
+		'query_var'          => false,
+		'label'              => esc_html__( '10up Support Monitor Log', 'tenup' ),
+		'has_archive'        => false,
+		'supports'           => [ 'title', 'editor' ],
+		'menu_icon'          => 'dashicons-book-alt',
+		'taxonomies'         => [],
+	);
+
+	register_post_type( CPT_SLUG, $args );
+
+}
+
+/**
+ * Logs an entry if the support monitor debugger has been enabled
+ *
+ * @param string $url - Full URL message was sent to
+ * @param array $message - Array of message parts
+ * @param array $response - Response of request to support monitor service
+ * @return void
+ */
+function maybe_add_log_entry( $url, $message, $response ) {
+
+	if ( ! is_debug_enabled() ) {
+		return;
+	}
+
+	$post_content = sprintf(
+		'<p>URL: %s</p><p>Message: %s</p><p>Response: %s</p>',
+		$url,
+		wp_json_encode( $message ),
+		wp_json_encode( $response )
+	);
+
+	wp_insert_post( [
+		'post_type'          => CPT_SLUG,
+		'post_status'        => 'publish',
+		'post_title'         => current_time( 'mysql' ),
+		'post_content'       => $post_content,
+	] );
+
+}
+
+/**
+ * Regisers the Support Monitor log link under the 'Tools' menu
+ *
+ * @return void
+ */
+function register_menu() {
+
+	add_submenu_page(
+		'tools.php',
+		esc_html__( '10up Support Monitor', 'tenup' ),
+		esc_html__( '10up Support Monitor', 'tenup' ),
+		'manage_options',
+		'edit.php?post_type=' . CPT_SLUG
+	);
+}
+
+/**
+ * Determines whether the debugger has been enabled
+ *
+ * @return boolean - true if defined and set, false if disabled
+ */
+function is_debug_enabled() {
+	return ( defined( 'SUPPORT_MONITOR_DEBUG' ) && SUPPORT_MONITOR_DEBUG );
+}

--- a/includes/support-monitor.php
+++ b/includes/support-monitor.php
@@ -155,7 +155,7 @@ function reset_queued_messages() {
 function queue_message( $message ) {
 	$messages = get_queued_messages();
 
-	$messages[] = $message;
+	$messages[] = format_message( $message );
 
 	if ( TENUP_EXPERIENCE_IS_NETWORK ) {
 		update_site_option( 'tenup_support_monitor_messages', $messages, false );
@@ -331,6 +331,8 @@ function setup_report_cron() {
  * @since 1.7
  */
 function send_daily_report() {
+	global $wpdb;
+
 	$setting = get_setting();
 
 	if ( empty( $setting['api_key'] ) || 'yes' !== $setting['enable_support_monitor'] ) {
@@ -342,7 +344,16 @@ function send_daily_report() {
 
 	$messages = [
 		format_message( get_plugin_report(), 'notice', 'plugins' ),
-		format_message( get_wp_version(), 'notice', 'wp_core' ),
+		format_message(
+			[
+				'wp_version' => get_wp_version(),
+				'wp_cache'   => ( defined( 'WP_CACHE' ) && WP_CACHE ),
+				'db_version' => $wpdb->db_version,
+				'wp_debug'   => ( defined( 'WP_DEBUG' ) && WP_DEBUG ),
+			],
+			'notice',
+			'wp'
+		),
 		format_message(
 			[
 				'php_version' => get_php_version(),

--- a/includes/support-monitor.php
+++ b/includes/support-monitor.php
@@ -343,7 +343,13 @@ function send_daily_report() {
 	$messages = [
 		format_message( get_plugin_report(), 'notice', 'plugins' ),
 		format_message( get_wp_version(), 'notice', 'wp_core' ),
-		format_message( get_php_version(), 'notice', 'system' ),
+		format_message(
+			[
+				'php_version' => get_php_version(),
+			],
+			'notice',
+			'system'
+		),
 	];
 
 	send_request( $messages );

--- a/includes/support-monitor.php
+++ b/includes/support-monitor.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * 10up suppport monitor code. This module lets us gather non-PII info from sites running
+ * the plugin e.g. plugin versions, WP version, etc.
+ *
+ * @since  1.7
+ * @package 10up-experience
+ */
+
+namespace TenUpExperience\SupportMonitor;
+
+/**
+ * Setup module
+ *
+ * @since 1.7
+ */
+function setup() {
+	if ( TENUP_EXPERIENCE_IS_NETWORK ) {
+		add_action( 'wpmu_options', __NAMESPACE__ . '\ms_settings' );
+		add_action( 'admin_init', __NAMESPACE__ . '\ms_save_settings' );
+	} else {
+		add_action( 'admin_init', __NAMESPACE__ . '\register_settings' );
+	}
+}
+
+/**
+ * Set options in multisite
+ *
+ * @since 1.7
+ */
+function ms_save_settings() {
+	global $pagenow;
+
+	if ( ! is_network_admin() ) {
+		return;
+	}
+
+	if ( 'settings.php' !== $pagenow ) {
+		return;
+	}
+
+	if ( ! is_super_admin() ) {
+		return;
+	}
+
+	if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'siteoptions' ) ) {
+		return;
+	}
+
+	if ( ! isset( $_POST['tenup_support_monitor_settings'] ) ) {
+		return;
+	}
+
+	$setting = get_setting();
+
+	if ( isset( $_POST['tenup_support_monitor_settings']['api_key'] ) ) {
+		$setting['api_key'] = sanitize_text_field( $_POST['tenup_support_monitor_settings']['api_key'] );
+	}
+
+	if ( isset( $_POST['tenup_support_monitor_settings']['enable_support_monitor'] ) ) {
+		$setting['enable_support_monitor'] = sanitize_text_field( $_POST['tenup_support_monitor_settings']['enable_support_monitor'] );
+	}
+
+	update_site_option( 'tenup_support_monitor_settings', $setting );
+}
+
+/**
+ * Output multisite settings
+ *
+ * @since 1.7
+ */
+function ms_settings() {
+	$setting = get_setting();
+	?>
+	<h2><?php esc_html_e( 'Support Monitor', 'tenup' ); ?>
+	<table class="form-table" role="presentation">
+		<tbody>
+			<tr>
+				<th scope="row">Enable</th>
+				<td>
+					<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'yes', $setting['enable_support_monitor'] ); ?> type="radio" id="tenup_enable_support_monitor_yes" value="yes"> <label for="tenup_enable_support_monitor_yes">Yes</label><br>
+					<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'no', $setting['enable_support_monitor'] ); ?> type="radio" id="tenup_enable_support_monitor_no" value="no"> <label for="tenup_enable_support_monitor_no">No</label>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">API Key</th>
+				<td>
+					<input name="tenup_support_monitor_settings[api_key]" type="text" id="tenup_api_key" value="<?php echo esc_attr( $setting['api_key'] ); ?>" class="regular-text">
+				</td>
+			</tr>
+		</tbody>
+	</table>
+	<?php
+}
+
+/**
+ * Get module
+ *
+ * @param  string $setting_key Setting key
+ * @since  1.7
+ * @return array
+ */
+function get_setting( $setting_key = null ) {
+	$defaults = [
+		'enable_support_monitor' => 'no',
+		'api_key'                => '',
+	];
+
+	$settings = ( TENUP_EXPERIENCE_IS_NETWORK ) ? get_site_option( 'tenup_support_monitor_settings', [] ) : get_option( 'tenup_support_monitor_settings', [] );
+	$settings = wp_parse_args( $settings, $defaults );
+
+	if ( ! empty( $setting_key ) ) {
+		return $settings[ $setting_key ];
+	}
+
+	return $settings;
+}
+
+
+/**
+ * Register settings
+ *
+ * @since 1.0
+ */
+function register_settings() {
+	add_settings_section(
+		'tenup_support_monitor',
+		esc_html__( 'Support Monitor', 'tenup' ),
+		'',
+		'general'
+	);
+
+	register_setting(
+		'general',
+		'tenup_support_monitor_settings',
+		[
+			'sanitize_callback' => __NAMESPACE__ . '\sanitize_settings',
+		]
+	);
+
+	add_settings_field(
+		'enable_support_monitor',
+		esc_html__( 'Enable', 'tenup' ),
+		__NAMESPACE__ . '\enable_field',
+		'general',
+		'tenup_support_monitor'
+	);
+
+	add_settings_field(
+		'api_key',
+		esc_html__( 'API Key', 'tenup' ),
+		__NAMESPACE__ . '\api_key_field',
+		'general',
+		'tenup_support_monitor'
+	);
+
+}
+
+/**
+ * Sanitize all settings
+ *
+ * @param  array $settings New settings
+ * @since  1.7
+ * @return array
+ */
+function sanitize_settings( $settings ) {
+	foreach ( $settings as $key => $setting ) {
+		$settings[ $key ] = sanitize_text_field( $setting );
+	}
+
+	return $settings;
+}
+
+/**
+ * Output enable field
+ *
+ * @since 1.7
+ */
+function enable_field() {
+	$value = get_setting( 'enable_support_monitor' );
+	?>
+	<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'yes', $value ); ?> type="radio" id="tenup_enable_support_monitor_yes" value="yes"> <label for="tenup_enable_support_monitor_yes"><?php esc_html_e( 'Yes', 'tenup' ); ?></label><br>
+	<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'no', $value ); ?> type="radio" id="tenup_enable_support_monitor_no" value="no"> <label for="tenup_enable_support_monitor_no"><?php esc_html_e( 'No', 'tenup' ); ?></label>
+	<?php
+}
+
+/**
+ * Output api key field
+ *
+ * @since 1.7
+ */
+function api_key_field() {
+	$value = get_setting( 'api_key' );
+	?>
+	<input name="tenup_support_monitor_settings[api_key]" type="text" id="tenup_api_key" value="<?php echo esc_attr( $value ); ?>" class="regular-text">
+	<?php
+}
+

--- a/includes/support-monitor.php
+++ b/includes/support-monitor.php
@@ -21,6 +21,10 @@ function setup() {
 	} else {
 		add_action( 'admin_init', __NAMESPACE__ . '\register_settings' );
 	}
+
+	add_action( 'tenup_support_monitor_message_cron', __NAMESPACE__ . '\send_cron_messages' );
+	add_action( 'admin_init', __NAMESPACE__ . '\setup_report_cron' );
+	add_action( 'send_daily_report_cron', __NAMESPACE__ . '\send_daily_report' );
 }
 
 /**
@@ -73,6 +77,9 @@ function ms_settings() {
 	$setting = get_setting();
 	?>
 	<h2><?php esc_html_e( 'Support Monitor', 'tenup' ); ?>
+
+	<?php setting_section_description(); ?>
+
 	<table class="form-table" role="presentation">
 		<tbody>
 			<tr>
@@ -116,6 +123,59 @@ function get_setting( $setting_key = null ) {
 	return $settings;
 }
 
+/**
+ * Get unsent messages
+ *
+ * @since  1.7
+ * @return array
+ */
+function get_queued_messages() {
+	return ( TENUP_EXPERIENCE_IS_NETWORK ) ? get_site_option( 'tenup_support_monitor_messages', [] ) : get_option( 'tenup_support_monitor_messages', [] );
+}
+
+/**
+ * Empty queued messages
+ *
+ * @since  1.7
+ */
+function reset_queued_messages() {
+	if ( TENUP_EXPERIENCE_IS_NETWORK ) {
+		update_site_option( 'tenup_support_monitor_messages', [], false );
+	} else {
+		update_option( 'tenup_support_monitor_messages', [], false );
+	}
+}
+
+/**
+ * Queue a message to be sent
+ *
+ * @param  array $message Message to queue
+ * @since  1.7
+ */
+function queue_message( $message ) {
+	$messages = get_queued_messages();
+
+	$messages[] = $message;
+
+	if ( TENUP_EXPERIENCE_IS_NETWORK ) {
+		update_site_option( 'tenup_support_monitor_messages', $messages, false );
+	} else {
+		update_option( 'tenup_support_monitor_messages', $messages, false );
+	}
+}
+
+/**
+ * Output setting section description
+ *
+ * @since 1.7
+ */
+function setting_section_description() {
+	?>
+	<p>
+		<?php esc_html_e( '10up collects data on site health including plugin, WordPress, and system versions as well as general site issues to provide proactive support to your website. No proprietary data or user information is sent back to us. Although recommended, this functionality is optional and can be disabled.' ); ?>
+	</p>
+	<?php
+}
 
 /**
  * Register settings
@@ -125,8 +185,8 @@ function get_setting( $setting_key = null ) {
 function register_settings() {
 	add_settings_section(
 		'tenup_support_monitor',
-		esc_html__( 'Support Monitor', 'tenup' ),
-		'',
+		esc_html__( '10up Support Monitor', 'tenup' ),
+		__NAMESPACE__ . '\setting_section_description',
 		'general'
 	);
 
@@ -194,5 +254,265 @@ function api_key_field() {
 	?>
 	<input name="tenup_support_monitor_settings[api_key]" type="text" id="tenup_api_key" value="<?php echo esc_attr( $value ); ?>" class="regular-text">
 	<?php
+}
+
+/**
+ * Sends a message async one time
+ *
+ * @param  array  $data Arbitrary data
+ * @param  string $type Message type. Can be notice, warning, or error.
+ * @param  string $group Message group
+ * @since  1.7
+ * @return boolean
+ */
+function format_message( $data, $type = 'notice', $group = 'message' ) {
+	$message = [
+		'time'       => time(),
+		'data'       => $data,
+		'type'       => $type,
+		'group'      => $group,
+		'message_id' => md5( get_setting( 'api_key' ) . microtime() ),
+	];
+
+	return apply_filters( 'tenup_support_monitor_message', $message );
+}
+
+/**
+ * Sends a message async one time
+ *
+ * @param  array  $data Arbitrary data
+ * @param  string $type Message type. Can be notice, warning, or error.
+ * @param  string $group Message group
+ * @return boolean
+ */
+function send_message( $data, $type = 'notice', $group = 'message' ) {
+
+	$setting = get_setting();
+
+	if ( empty( $setting['api_key'] ) || 'yes' !== $setting['enable_support_monitor'] ) {
+		wp_unschedule_hook( 'tenup_support_monitor_message_cron' );
+
+		return false;
+	}
+
+	if ( ! wp_next_scheduled( 'tenup_support_monitor_message_cron' ) ) {
+		queue_message( format_message( $data, $type ) );
+
+		return wp_schedule_single_event( time(), 'tenup_support_monitor_message_cron' );
+	}
+
+	return true;
+}
+
+/**
+ * Setup daily report cron
+ *
+ * @since  1.7
+ */
+function setup_report_cron() {
+	$setting = get_setting();
+
+	if ( empty( $setting['api_key'] ) || 'yes' !== $setting['enable_support_monitor'] ) {
+		if ( wp_next_scheduled( 'send_daily_report_cron' ) ) {
+			wp_unschedule_hook( 'send_daily_report_cron' );
+		}
+
+		return;
+	}
+
+	if ( ! wp_next_scheduled( 'send_daily_report_cron' ) ) {
+		wp_schedule_event( time(), 'twicedaily', 'send_daily_report_cron' );
+	}
+}
+
+/**
+ * Send the daily report async
+ *
+ * @since 1.7
+ */
+function send_daily_report() {
+	$setting = get_setting();
+
+	if ( empty( $setting['api_key'] ) || 'yes' !== $setting['enable_support_monitor'] ) {
+		return;
+	}
+
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	require_once ABSPATH . 'wp-admin/includes/update.php';
+
+	$messages = [
+		format_message( get_plugin_report(), 'notice', 'plugins' ),
+		format_message( get_wp_version(), 'notice', 'wp_core' ),
+		format_message( get_php_version(), 'notice', 'system' ),
+	];
+
+	send_request( $messages );
+}
+
+/**
+ * Send messages to hub
+ *
+ * @param  array $messages Array of messages
+ * @since  1.7
+ */
+function send_request( $messages ) {
+	$api_url = apply_filters( 'tenup_support_monitor_api_url', 'https://10up.com', $messages );
+
+	wp_remote_request(
+		$api_url,
+		[
+			'method'   => 'POST',
+			'body'     => wp_json_encode( $messages ),
+			'blocking' => false,
+			'headers'  => [
+				'X-Tenup-Support-Monitor-Key' => get_setting( 'api_key' ),
+			],
+		]
+	);
+}
+
+/**
+ * Send all the queued messages
+ *
+ * @since  1.7
+ */
+function send_cron_messages() {
+	$messages = get_queued_messages();
+
+	send_request( $messages );
+
+	reset_queued_messages();
+}
+
+/**
+ * Get WP plugins
+ *
+ * @since  1.7
+ * @return array
+ */
+function get_plugin_report() {
+
+	$plugins = [];
+
+	$_plugins = get_mu_plugins();
+
+	foreach ( $_plugins as $file => $plugin ) {
+		$plugins[] = [
+			'slug'    => get_plugin_name( $file ),
+			'name'    => $plugin['Name'],
+			'status'  => 'must-use',
+			'version' => $plugin['Version'],
+		];
+	}
+
+	$_plugins = get_plugins();
+
+	foreach ( $_plugins as $file => $plugin ) {
+		$plugins[] = [
+			'slug'    => get_plugin_name( $file ),
+			'name'    => $plugin['Name'],
+			'status'  => get_status( $file ),
+			'version' => $plugin['Version'],
+		];
+	}
+	return $plugins;
+}
+
+/**
+ * Get WP version
+ *
+ * @since  1.7
+ * @return string
+ */
+function get_wp_version() {
+	$data = get_preferred_from_update_core();
+	return $data->version;
+}
+
+/**
+ * Get name of plugin from file
+ *
+ * @param  string $basename File name
+ * @since  1.7
+ * @return string
+ */
+function get_plugin_name( $basename ) {
+	if ( false === strpos( $basename, '/' ) ) {
+		$name = basename( $basename, '.php' );
+	} else {
+		$name = dirname( $basename );
+	}
+	return $name;
+}
+
+/**
+ * Get status for plugin
+ *
+ * @param  string $file File name for plugin
+ * @since  1.7
+ * @return string
+ */
+function get_status( $file ) {
+	if ( is_plugin_active_for_network( $file ) ) {
+		return 'active-network';
+	} if ( is_plugin_active( $file ) ) {
+		return 'active';
+	}
+
+	return 'inactive';
+}
+
+/**
+ * Get PHP version for site
+ *
+ * @since  1.7
+ * @return string
+ */
+function get_php_version() {
+	return phpversion();
+}
+
+
+/**
+ * Get users for site
+ *
+ * @since  1.7
+ * @return array
+ */
+function get_users() {
+	$users = [];
+
+	$args = [
+		'search'         => '*@get10up.com',
+		'search_columns' => [ 'user_email' ],
+		'number'         => '100',
+	];
+
+	$_users = get_users( $args );
+
+	foreach ( $_users as $user ) {
+		$users[] = [
+			'email'        => $user->user_email,
+			'display_name' => $user->display_name,
+			'role'         => $user->roles,
+		];
+	}
+
+	$args = [
+		'search'         => '*@10up.com',
+		'search_columns' => [ 'user_email' ],
+		'number'         => '100',
+	];
+
+	$_users = get_users( $args );
+
+	foreach ( $_users as $user ) {
+		$users[] = [
+			'email'        => $user->user_email,
+			'display_name' => $user->display_name,
+			'role'         => $user->roles,
+		];
+	}
+	return $users;
 }
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Utility functions
+ *
+ * @since  1.7
+ * @package  10up-experience
+ */
+
+namespace TenUpExperience\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+
+/**
+ * Whether plugin is network activated
+ *
+ * Determines whether plugin is network activated or just on the local site.
+ *
+ * @since 1.7
+ * @param string $plugin the plugin base name.
+ * @return bool True if network activated or false.
+ */
+function is_network_activated( $plugin ) {
+	$plugins = get_site_option( 'active_sitewide_plugins' );
+
+	if ( is_multisite() && isset( $plugins[ $plugin ] ) ) {
+		return true;
+	}
+
+	return false;
+}


### PR DESCRIPTION
Add debugger functionality to the 10up Support Monitor. By setting `define( 'SUPPORT_MONITOR_DEBUG', true );` in wp-config.php this will create a log CPT for logging all messages sent to the support monitor API.