### PR TITLE
set x-frame-options to SAMEORIGIN to avoid clickjacking attacks

### DIFF
--- a/10up-experience.php
+++ b/10up-experience.php
@@ -71,6 +71,7 @@ Authentication\Passwords::instance()->setup();
 Authentication\Usernames::instance()->setup();
 Authors\Authors::instance()->setup();
 Gutenberg\Gutenberg::instance()->setup();
+Headers\Headers::instance()->setup();
 Plugins\Plugins::instance()->setup();
 PostPasswords\PostPasswords::instance()->setup();
 SupportMonitor\Monitor::instance()->setup();

--- a/includes/classes/Headers/Headers.php
+++ b/includes/classes/Headers/Headers.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Header customizations
+ *
+ * @package  10up-experience
+ */
+
+namespace TenUpExperience\Headers;
+
+use TenUpExperience\Singleton;
+
+/**
+ * Headers class
+ */
+class Headers extends Singleton {
+	/**
+	 * Setup module
+	 */
+	public function setup() {
+		add_action( 'wp_headers', [ $this, 'maybe_set_frame_option_header' ], 99, 1 );
+	}
+
+	/**
+	 * Set the X-Frame-Options header to 'SAMEORIGIN' to prevent clickjacking attacks
+	 *
+	 * @param string $headers Headers
+	 */
+	public function maybe_set_frame_option_header( $headers ) {
+		$header_value               = apply_filters( 'tenup_experience_x_frame_options', 'SAMEORIGIN' );
+		$headers['X-Frame-Options'] = $header_value;
+		return $headers;
+	}
+}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

set x-frame-options to SAMEORIGIN to avoid clickjacking attacks
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Benefits

Helps prevents clickjacking attacks.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Could cause issues if you are embedding the site on another site.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Manually look at the headers that are getting set.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->


### Changelog Entry

Adds protection against clickjacking attacks.
<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
