### PR TITLE
Fix a esc_html__ call

### DIFF
--- a/includes/classes/Authentication/Passwords.php
+++ b/includes/classes/Authentication/Passwords.php
@@ -176,7 +176,7 @@ class Passwords extends Singleton {
 				'Auth Error',
 				sprintf(
 					'%s <a href="%s">%s</a> %s',
-					ecc_html__( 'Please', 'tenup' ),
+					esc_html__( 'Please', 'tenup' ),
 					esc_url( wp_lostpassword_url() ),
 					esc_html__( 'reset your password', 'tenup' ),
 					esc_html__( 'in order to meet current security measures.', 'tenup' )


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Fix a esc_html__() call.

### Alternate Designs

n/a


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes #71 

### Changelog Entry

Fix a call to esc_html__() in the weak password check
