### PR TITLE
Strengthens detection of an external object cache

### DIFF
--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -449,7 +449,7 @@ class Monitor extends Singleton {
 				[
 					'wp_version'           => $this->get_wp_version(),
 					'wp_cache'             => ( defined( 'WP_CACHE' ) && WP_CACHE ),
-					'object_cache_enabled' => wp_using_ext_object_cache(),
+					'object_cache_enabled' => $this->get_is_using_object_cache(),
 					'db_version'           => ( isset( $wpdb->db_version ) ) ? $wpdb->db_version : '',
 					'wp_debug'             => ( defined( 'WP_DEBUG' ) && WP_DEBUG ),
 					'disallow_file_mods'   => ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ),
@@ -685,5 +685,28 @@ class Monitor extends Singleton {
 		}
 
 		return $report;
+	}
+
+	/**
+	 * Check if the site is using an external object cache.
+	 *
+	 * Manually sets a value into an external object cache and attempts the retrieve
+	 * it. This is needed for caching drop-ins that do not set the
+	 * $_wp_using_ext_object_cache global varialbe, for example Redis Cache Pro.
+	 *
+	 * @return bool
+	 */
+	public function get_is_using_object_cache() {
+		if ( wp_using_ext_object_cache() ) {
+			return true;
+		}
+
+		$check = time();
+
+		wp_cache_set( 'tenup_experience_cache_check', $check, null, MINUTE_IN_SECONDS );
+
+		$result = wp_cache_get( 'foo' );
+
+		return ( $result === $check );
 	}
 }

--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -690,10 +690,6 @@ class Monitor extends Singleton {
 	/**
 	 * Check if the site is using an external object cache.
 	 *
-	 * Manually sets a value into an external object cache and attempts the retrieve
-	 * it. This is needed for caching drop-ins that do not set the
-	 * $_wp_using_ext_object_cache global varialbe, for example Redis Cache Pro.
-	 *
 	 * @return bool
 	 */
 	public function get_is_using_object_cache() {
@@ -701,12 +697,6 @@ class Monitor extends Singleton {
 			return true;
 		}
 
-		$check = time();
-
-		wp_cache_set( 'tenup_experience_cache_check', $check, null, MINUTE_IN_SECONDS );
-
-		$result = wp_cache_get( 'tenup_experience_cache_check' );
-
-		return ( $result === $check );
+		return file_exists( WP_CONTENT_DIR . '/object-cache.php' );
 	}
 }

--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -705,7 +705,7 @@ class Monitor extends Singleton {
 
 		wp_cache_set( 'tenup_experience_cache_check', $check, null, MINUTE_IN_SECONDS );
 
-		$result = wp_cache_get( 'foo' );
+		$result = wp_cache_get( 'tenup_experience_cache_check' );
 
 		return ( $result === $check );
 	}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Strengthens detection of an external object cache.

### Alternate Designs

Some plugins, like Object Cache Pro (formerly Redis Cache Pro) do not set the `$_wp_using_ext_object_cache` global, or at least detection using that method was failing.

### Benefits

Stronger object cache detection.

### Possible Drawbacks

None