### PR TITLE
Trigger Web Vital reporting with Support Monitor on Production environments

### DIFF
--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -476,7 +476,7 @@ class Monitor extends Singleton {
 		if ( 'yes' === $setting['production_environment'] ) {
 			$messages[] = $this->format_message(
 				[
-					'url' => 'https://10up.com/',
+					'url' => home_url(),
 				],
 				'notice',
 				'webvitals'

--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -472,6 +472,17 @@ class Monitor extends Singleton {
 			),
 		];
 
+		// If this is production, request that a web vitals insight also be generated.
+		if ( 'yes' === $setting['production_environment'] ) {
+			$messages[] = $this->format_message(
+				[
+					'url' => 'https://10up.com/',
+				],
+				'notice',
+				'webvitals'
+			);
+		}
+
 		$this->send_request( $messages );
 	}
 


### PR DESCRIPTION
### Description of the Change

Updates the support monitor queued messages to include a message that triggers a web vitals test be run if the site is denoted as the production environment.

### Benefits

Adds support for notifying support monitor users of:
 - Largest Contentful Paint
 - Cumulative Layout Shift
 - First Input Delay
 - First Contentful Paint 

see https://web.dev/vitals/

### Possible Drawbacks

none

### Verification Process


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- Enter any applicable Issues here -->

### Changelog Entry

- Adds a support monitor message to trigger [web vital ](https://web.dev/vitals/) reporting on production environments.
