### PR TITLE
Feature/filter enable x frame options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@
 
 *Note:* 10up admin branding can be disabled by defining the constant `TENUP_DISABLE_BRANDING` as `true`.
 
+There are 2 filters available here:
+- `tenup_experience_x_frame_options` - (default value) `SAMEORIGIN` can be changed to `DENY`.
+- `tenup_experience_disable_x_frame_options` - (default value) `FALSE` can be changed to `TRUE` - doing so will omit the header.
+
 ## Support Level
 
 **Active:** 10up is actively working on this, and we expect to continue work for the foreseeable future including keeping tested up to the most recent version of WordPress.  Bug reports, feature requests, questions, and pull requests are welcome.

--- a/includes/classes/Headers/Headers.php
+++ b/includes/classes/Headers/Headers.php
@@ -26,6 +26,13 @@ class Headers extends Singleton {
 	 * @param string $headers Headers
 	 */
 	public function maybe_set_frame_option_header( $headers ) {
+
+		// Allow omission of this header
+		if ( true === apply_filters( 'tenup_experience_disable_x_frame_options', false ) ) {
+			return $headers;
+		}
+
+		// Valid header values are `SAMEORIGIN` (allow iframe on same domain) | `DENY` (do not allow anywhere)
 		$header_value               = apply_filters( 'tenup_experience_x_frame_options', 'SAMEORIGIN' );
 		$headers['X-Frame-Options'] = $header_value;
 		return $headers;


### PR DESCRIPTION
### Description of the Change

According to [Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options), X-Frame-Options only has 2 valid values:
- `SAMEORIGIN` - Only allow an iframe to be used on the same domain
- `DENY` - Do not allow any embedded iframe

The existing filter only allows for this to be changed from (default) `SAMEORIGIN` to `DENY`

### Benefits

There is an option to filter `wp_headers` to remove this header, if present; this additional filter allows setting the header to be bypassed entirely.

### Possible Drawbacks

None

### Verification Process

`add_filter( 'tenup_experience_disable_x_frame_options', true )` - result is the header is not set.

### Checklist:

- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document. **No, the file doesn't exist in this repo**
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. **Maybe**
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change. **There are no existing tests; should these be added?**
- [ ] All new and existing tests passed.

### Changelog Entry

Added: filter `tenup_experience_disable_x_frame_options` to allow omission of the X-Frame-Options header.