### PR TITLE
Fix Filtering WP List Table Views by 10up Author

### DIFF
--- a/includes/classes/Authors/Authors.php
+++ b/includes/classes/Authors/Authors.php
@@ -27,7 +27,7 @@ class Authors extends Singleton {
 	 */
 	public function maybe_disable_author_archive() {
 
-		if ( ! is_author() ) {
+		if ( ! is_author() || is_admin() ) {
 			return;
 		}
 


### PR DESCRIPTION
### Description of the Change

This PR addresses the bug reported at #78 where users get redirected to the homepage when trying to filter the WP List Post table by a user that has a 10up email address. 

### Benefits

Allows 10up users to filter content in the WordPress admin that they have authored. This comes in handy when you're trying to delete any test post you might have made or when you want to attribute all your content to someone else. 

### Possible Drawbacks

None

### Verification Process

1. Create a user capable of creating posts
2. Assign an email address with the domain of 10up.com or get10up.com
3. Create a few post while logged in as the new user
4. Navigate to the All Post screen in the WordPress admin
5. Click on the author name of the newly created users
6. You should see all the post you just created and not get directed to the homepage

**If you try and view that users Author archive on the frontend you should still be redirected to the homepage.**

### Checklist:
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

#78 

### Changelog Entry

Fixes a bug that redirected a user to the homepage when trying to filter a WP List Table by a 10up author 
