### PR TITLE
Unhide Stream Menu Link

### DIFF
--- a/includes/classes/Plugins/Plugins.php
+++ b/includes/classes/Plugins/Plugins.php
@@ -19,7 +19,6 @@ class Plugins extends Singleton {
 	 * @since 1.7
 	 */
 	public function setup() {
-		add_action( 'admin_init', [ $this, 'plugin_customizations' ] );
 		add_filter( 'install_plugins_tabs', [ $this, 'tenup_plugin_install_link' ] );
 		add_filter( 'install_plugins_table_api_args_tenup', [ $this, 'filter_install_plugin_args' ] );
 
@@ -48,41 +47,6 @@ class Plugins extends Singleton {
 			add_action( 'network_admin_menu', [ $this, 'set_plugin_menu_update_count' ], 99 );
 			add_filter( 'show_advanced_plugins', [ $this, 'set_global_plugin_data' ], 10 );
 			add_filter( 'show_network_active_plugins', [ $this, 'set_global_plugin_data' ], 10 );
-		}
-	}
-
-	/**
-	 * Start plugin customizations
-	 */
-	public function plugin_customizations() {
-
-		/**
-		 * Stream
-		 */
-
-		/**
-		 * Filters whether to remove stream menu item.
-		 *
-		 * @since 1.1.0
-		 *
-		 * @param bool $tenup_experience_remove_stream_menu_item Whether to remove menu item. Default is true.
-		 */
-		$remove_menu_item = apply_filters( 'tenup_experience_remove_stream_menu_item', true );
-
-		if ( is_plugin_active( 'stream/stream.php' ) && $remove_menu_item ) {
-
-			add_action(
-				'admin_init',
-				function() {
-					// Don't proceed if doing admin ajax as "remove_menu_page" produces a Invalid argument supplied for foreach() warning
-					if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-						return;
-					}
-
-					remove_menu_page( 'wp_stream' );
-				},
-				11
-			);
 		}
 	}
 


### PR DESCRIPTION
### Description of the Change

Removes the code that was hiding the stream admin menu links.

### Benefits

Makes it easier to find the stream plugin dashboard. 

### Verification Process

1. Install and Activate stream plugin
2. If logged in as an admin the stream menu item should appear below the dashboard one.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Resolves #88 

### Changelog Entry

Removes logic that was hiding the stream admin menu item.
