### PR TITLE
Disable widgets block editor

### DIFF
--- a/includes/classes/Gutenberg/Gutenberg.php
+++ b/includes/classes/Gutenberg/Gutenberg.php
@@ -90,5 +90,8 @@ class Gutenberg extends Singleton {
 
 		// Gutenberg plugin
 		add_filter( 'gutenberg_can_edit_post', '__return_false' );
+
+		// Disable Widgets block editor, by default it is enabled in WordPress 5.8
+		add_filter( 'use_widgets_block_editor', '__return_false' );
 	}
 }


### PR DESCRIPTION
### Description of the Change

The block-based widgets editor is enabled in WordPress 5.8 by default. The PR uses the provided filter in https://make.wordpress.org/core/2021/06/29/block-based-widgets-editor-in-wordpress-5-8/ to disable the block editor in Widgets screen. 


### Alternate Designs

- Should a new option to disable Widgets block editor be added in `Settings` > `Writing`?


### Benefits

- Automatically disable block editor in Widgets screen if following checkbox is selected.

![Screenshot 2021-07-13 at 2 49 40 AM](https://user-images.githubusercontent.com/13589980/125357234-fcb76e00-e384-11eb-9f58-f07b6c401424.png)


### Possible Drawbacks

N/A

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

- Disable block editor for widgets added in 5.8 