### PR TITLE
Adjust markup for radio and checkbox fields to match WordPress Core

### DIFF
--- a/includes/classes/Authentication/Passwords.php
+++ b/includes/classes/Authentication/Passwords.php
@@ -61,10 +61,7 @@ class Passwords extends Singleton {
 			esc_html__( 'Require Strong Passwords', 'tenup' ),
 			[ $this, 'settings_ui' ],
 			'general',
-			'default',
-			array(
-				'label_for' => 'require-strong-passwords',
-			)
+			'default'
 		);
 	}
 
@@ -130,12 +127,22 @@ class Passwords extends Singleton {
 			<tbody>
 				<tr>
 					<th scope="row">
-						<label for="require-strong-passwords"><?php esc_html_e( 'Require Strong Passwords', 'tenup' ); ?></label>
+						<?php esc_html_e( 'Require Strong Passwords', 'tenup' ); ?>
 					</th>
 					<td>
-						<input name="tenup_require_strong_passwords" <?php checked( 1, $require_strong_passwords ); ?> type="radio" id="require-strong-passwords-yes" value="1"> <label for="require-strong-passwords-yes"><?php esc_html_e( 'Yes', 'tenup' ); ?></label><br>
-						<input name="tenup_require_strong_passwords" <?php checked( 0, $require_strong_passwords ); ?> type="radio" id="require-strong-passwords-no" value="0"> <label for="require-strong-passwords-no"><?php esc_html_e( 'No', 'tenup' ); ?></label>
-						<p class="description"><?php esc_html_e( 'Require all users to use strong passwords.', 'tenup' ); ?></p>
+						<fieldset>
+							<legend class="screen-reader-text"><span><?php esc_html_e( 'Require Strong Passwords', 'tenup' ); ?></span></legend>
+							<label for="require-strong-passwords-yes">
+								<input name="tenup_require_strong_passwords" <?php checked( 1, $require_strong_passwords ); ?> type="radio" id="require-strong-passwords-yes" value="1">
+								<?php esc_html_e( 'Yes', 'tenup' ); ?>
+							</label><br>
+							<label for="require-strong-passwords-no">
+								<input name="tenup_require_strong_passwords" <?php checked( 0, $require_strong_passwords ); ?> type="radio" id="require-strong-passwords-no" value="0">
+								<?php esc_html_e( 'No', 'tenup' ); ?>
+							</label>
+							</label>
+							<p class="description"><?php esc_html_e( 'Require all users to use strong passwords.', 'tenup' ); ?></p>
+						</fieldset>
 					</td>
 				</tr>
 			</tbody>
@@ -152,9 +159,19 @@ class Passwords extends Singleton {
 		$require_strong_passwords = $this->require_strong_passwords();
 
 		?>
-		<input name="tenup_require_strong_passwords" <?php checked( 1, $require_strong_passwords ); ?> type="radio" id="require-strong-passwords-yes" value="1"> <label for="require-strong-passwords-yes"><?php esc_html_e( 'Yes', 'tenup' ); ?></label><br>
-		<input name="tenup_require_strong_passwords" <?php checked( 0, $require_strong_passwords ); ?> type="radio" id="require-strong-passwords-no" value="0"> <label for="require-strong-passwords-no"><?php esc_html_e( 'No', 'tenup' ); ?></label>
-		<p class="description"><?php esc_html_e( 'Require all users to use strong passwords.', 'tenup' ); ?></p>
+		<fieldset>
+			<legend class="screen-reader-text"><span><?php esc_html_e( 'Require Strong Passwords', 'tenup' ); ?></span></legend>
+			<label for="require-strong-passwords-yes">
+				<input name="tenup_require_strong_passwords" <?php checked( 1, $require_strong_passwords ); ?> type="radio" id="require-strong-passwords-yes" value="1">
+				<?php esc_html_e( 'Yes', 'tenup' ); ?>
+			</label><br>
+			<label for="require-strong-passwords-no">
+				<input name="tenup_require_strong_passwords" <?php checked( 0, $require_strong_passwords ); ?> type="radio" id="require-strong-passwords-no" value="0">
+				<?php esc_html_e( 'No', 'tenup' ); ?>
+			</label>
+			</label>
+			<p class="description"><?php esc_html_e( 'Require all users to use strong passwords.', 'tenup' ); ?></p>
+		</fieldset>
 		<?php
 	}
 

--- a/includes/classes/Gutenberg/Gutenberg.php
+++ b/includes/classes/Gutenberg/Gutenberg.php
@@ -58,10 +58,10 @@ class Gutenberg extends Singleton {
 		?>
 		<fieldset>
 			<legend class="screen-reader-text"><?php esc_html_e( 'Gutenberg Editor Settings', 'tenup' ); ?></legend>
-			<p>
+			<label for="disable-gutenberg-editor">
 				<input id="disable-gutenberg-editor" name="<?php echo esc_attr( $this->get_disable_gutenberg_key() ); ?>" type="checkbox" value="1" <?php checked( $disable_editor, 1 ); ?> />
-			</p>
-			<p class="description"><?php esc_html_e( 'Disables Gutenberg, the new editor introduced in WordPress 5.0, in favor of the prior writing experience.', 'tenup' ); ?></p>
+				<?php esc_html_e( 'Disables Gutenberg, the new editor introduced in WordPress 5.0, in favor of the prior writing experience.', 'tenup' ); ?>
+			</label>
 		</fieldset>
 		<?php
 	}

--- a/includes/classes/PostPasswords/PostPasswords.php
+++ b/includes/classes/PostPasswords/PostPasswords.php
@@ -58,10 +58,10 @@ class PostPasswords extends Singleton {
 		?>
 		<fieldset>
 			<legend class="screen-reader-text"><?php esc_html_e( 'Password Protected Content', 'tenup' ); ?></legend>
-			<p>
+			<label for="password-protect">
 				<input id="password-protect" name="tenup_password_protect" type="checkbox" value="1" <?php checked( $password_protect, 1 ); ?> />
-			</p>
-			<p class="description"><?php esc_html_e( 'Enables password protected content. WordPress default password protected post functionality is insecure and does not work with page caching.', 'tenup' ); ?></p>
+				<?php esc_html_e( 'Enables password protected content. WordPress default password protected post functionality is insecure and does not work with page caching.', 'tenup' ); ?>
+			</label>
 		</fieldset>
 		<?php
 	}

--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -121,8 +121,17 @@ class Monitor extends Singleton {
 				<tr>
 					<th scope="row"><?php esc_html_e( 'Production Environment', 'tenup' ); ?></th>
 					<td>
-						<input name="tenup_support_monitor_settings[production_environment]" <?php checked( 'yes', $setting['production_environment'] ); ?> type="radio" id="tenup_production_environment_yes" value="yes"> <label for="tenup_production_environment_yes"><?php esc_html_e( 'Yes', 'tenup' ); ?></label><br>
-						<input name="tenup_support_monitor_settings[production_environment]" <?php checked( 'no', $setting['production_environment'] ); ?> type="radio" id="tenup_production_environment_no" value="no"> <label for="tenup_production_environment_no"><?php esc_html_e( 'No', 'tenup' ); ?></label>
+						<fieldset>
+							<legend class="screen-reader-text"><span><?php esc_html_e( 'Production Environment', 'tenup' ); ?></span></legend>
+							<label for="tenup_production_environment_yes">
+								<input name="tenup_support_monitor_settings[production_environment]" <?php checked( 'yes', $setting['production_environment'] ); ?> type="radio" id="tenup_production_environment_yes" value="yes">
+								<?php esc_html_e( 'Yes', 'tenup' ); ?>
+							</label><br>
+							<label for="tenup_production_environment_no">
+								<input name="tenup_support_monitor_settings[production_environment]" <?php checked( 'no', $setting['production_environment'] ); ?> type="radio" id="tenup_production_environment_no" value="no">
+								<?php esc_html_e( 'No', 'tenup' ); ?>
+							</label>
+						</fieldset>
 					</td>
 				</tr>
 				<?php if ( Debug::instance()->is_debug_enabled() ) : ?>
@@ -323,8 +332,17 @@ class Monitor extends Singleton {
 	public function production_environment_field() {
 		$value = $this->get_setting( 'production_environment' );
 		?>
-		<input name="tenup_support_monitor_settings[production_environment]" <?php checked( 'yes', $value ); ?> type="radio" id="tenup_production_environment_yes" value="yes"> <label for="tenup_production_environment_yes"><?php esc_html_e( 'Yes', 'tenup' ); ?></label><br>
-		<input name="tenup_support_monitor_settings[production_environment]" <?php checked( 'no', $value ); ?> type="radio" id="tenup_production_environment_no" value="no"> <label for="tenup_production_environment_no"><?php esc_html_e( 'No', 'tenup' ); ?></label>
+		<fieldset>
+			<legend class="screen-reader-text"><span><?php esc_html_e( 'Production Environment', 'tenup' ); ?></span></legend>
+			<label for="tenup_production_environment_yes">
+				<input name="tenup_support_monitor_settings[production_environment]" <?php checked( 'yes', $value ); ?> type="radio" id="tenup_production_environment_yes" value="yes">
+				<?php esc_html_e( 'Yes', 'tenup' ); ?>
+			</label><br>
+			<label for="tenup_production_environment_no">
+				<input name="tenup_support_monitor_settings[production_environment]" <?php checked( 'no', $value ); ?> type="radio" id="tenup_production_environment_no" value="no">
+				<?php esc_html_e( 'No', 'tenup' ); ?>
+			</label>
+		</fieldset>
 		<?php
 	}
 

--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -99,8 +99,17 @@ class Monitor extends Singleton {
 				<tr>
 					<th scope="row"><?php esc_html_e( 'Enable', 'tenup' ); ?></th>
 					<td>
-						<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'yes', $setting['enable_support_monitor'] ); ?> type="radio" id="tenup_enable_support_monitor_yes" value="yes"> <label for="tenup_enable_support_monitor_yes"><?php esc_html_e( 'Yes', 'tenup' ); ?></label><br>
-						<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'no', $setting['enable_support_monitor'] ); ?> type="radio" id="tenup_enable_support_monitor_no" value="no"> <label for="tenup_enable_support_monitor_no"><?php esc_html_e( 'No', 'tenup' ); ?></label>
+						<fieldset>
+							<legend class="screen-reader-text"><span><?php esc_html_e( 'Enable Support Monitor', 'tenup' ); ?></span></legend>
+							<label for="tenup_enable_support_monitor_yes">
+								<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'yes', $setting['enable_support_monitor'] ); ?> type="radio" id="tenup_enable_support_monitor_yes" value="yes">
+								<?php esc_html_e( 'Yes', 'tenup' ); ?>
+							</label><br>
+							<label for="tenup_enable_support_monitor_no">
+								<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'no', $setting['enable_support_monitor'] ); ?> type="radio" id="tenup_enable_support_monitor_no" value="no">
+								<?php esc_html_e( 'No', 'tenup' ); ?>
+							</label>
+						</fieldset>
 					</td>
 				</tr>
 				<tr>
@@ -292,8 +301,17 @@ class Monitor extends Singleton {
 	public function enable_field() {
 		$value = $this->get_setting( 'enable_support_monitor' );
 		?>
-		<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'yes', $value ); ?> type="radio" id="tenup_enable_support_monitor_yes" value="yes"> <label for="tenup_enable_support_monitor_yes"><?php esc_html_e( 'Yes', 'tenup' ); ?></label><br>
-		<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'no', $value ); ?> type="radio" id="tenup_enable_support_monitor_no" value="no"> <label for="tenup_enable_support_monitor_no"><?php esc_html_e( 'No', 'tenup' ); ?></label>
+		<fieldset>
+			<legend class="screen-reader-text"><span><?php esc_html_e( 'Enable Support Monitor', 'tenup' ); ?></span></legend>
+			<label for="tenup_enable_support_monitor_yes">
+				<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'yes', $value ); ?> type="radio" id="tenup_enable_support_monitor_yes" value="yes">
+				<?php esc_html_e( 'Yes', 'tenup' ); ?>
+			</label><br>
+			<label for="tenup_enable_support_monitor_no">
+				<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'no', $value ); ?> type="radio" id="tenup_enable_support_monitor_no" value="no">
+				<?php esc_html_e( 'No', 'tenup' ); ?>
+			</label>
+		</fieldset>
 		<?php
 	}
 


### PR DESCRIPTION
### Description of the Change

Addresses #41 to fix the alignment of checkbox and radio fields in the wp-admin. Radios and checkboxes now follow the same markup as WordPress Core.

### Benefits

Accessibility and keyboard usability of the admin pages should be a little cleaner with these changes.

### Possible Drawbacks

Breaking the settings fields.

### Verification Process

- How did you verify that all new functionality works as expected? 

Installed the plugin on a local instance, made my changes and saved each settings field multiple times:

Disable Gutenberg - https://tenup.test/wp-admin/options-writing.php

Enable Password Protection - https://tenup.test/wp-admin/options-writing.php

Enable Support Monitor - https://tenup.test/wp-admin/options-general.php

Production Environment - https://tenup.test/wp-admin/options-general.php

And also for multisite - https://tenup.test/wp-admin/network/settings.php

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.

### Changelog Entry

Changed admin markup for Disable Gutenberg, Enable Password Protection, Enable Support Monitor, and Production Environment
