### PR TITLE
DB Query Monitor

### DIFF
--- a/10up-experience.php
+++ b/10up-experience.php
@@ -70,19 +70,19 @@ $network_activated = Utils\is_network_activated( plugin_basename( __FILE__ ) );
 define( 'TENUP_EXPERIENCE_IS_NETWORK', (bool) $network_activated );
 
 if ( ! defined( 'TENUP_DISABLE_BRANDING' ) || ! TENUP_DISABLE_BRANDING ) {
-	AdminCustomizations\Customizations::instance()->setup();
+	AdminCustomizations\Customizations::instance();
 }
 
-API\API::instance()->setup();
-Authentication\Usernames::instance()->setup();
-Authors\Authors::instance()->setup();
-Gutenberg\Gutenberg::instance()->setup();
-Headers\Headers::instance()->setup();
-Plugins\Plugins::instance()->setup();
-PostPasswords\PostPasswords::instance()->setup();
-SupportMonitor\Monitor::instance()->setup();
-SupportMonitor\Debug::instance()->setup();
-Notifications\Welcome::instance()->setup();
+API\API::instance();
+Authentication\Usernames::instance();
+Authors\Authors::instance();
+Gutenberg\Gutenberg::instance();
+Headers\Headers::instance();
+Plugins\Plugins::instance();
+PostPasswords\PostPasswords::instance();
+SupportMonitor\Monitor::instance();
+SupportMonitor\Debug::instance();
+Notifications\Welcome::instance();
 
 /**
  * We load this later to make sure there are no conflicts with other plugins.
@@ -90,7 +90,7 @@ Notifications\Welcome::instance()->setup();
 add_action(
 	'plugins_loaded',
 	function() {
-		Authentication\Passwords::instance()->setup();
+		Authentication\Passwords::instance();
 	}
 );
 

--- a/includes/classes/SupportMonitor/DBQueryMonitor.php
+++ b/includes/classes/SupportMonitor/DBQueryMonitor.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Database Queries Monitor. A submodule of Support Monitor to report heavy SQL queries executed on staging.
+ *
+ * @since  x.x
+ * @package 10up-experience
+ */
+
+namespace TenUpExperience\SupportMonitor;
+
+/**
+ * DBQueryMonitor class
+ */
+class DBQueryMonitor {
+
+	/**
+	 * The transient name
+	 *
+	 * This transient stores all the queries logged.
+	 */
+	const TRANSIENT_NAME = 'tenup_experience_db_queries';
+
+	/**
+	 * Setup module
+	 */
+	public function setup() {
+		$production_environment = Monitor::instance()->get_setting( 'production_environment' );
+		if ( 'no' === $production_environment || apply_filters( 'tenup_experience_log_heavy_queries', false ) ) {
+			add_filter( 'query', [ $this, 'maybe_log_query' ] );
+		}
+	}
+
+	/**
+	 * Conditionally log a query
+	 *
+	 * Get all potential heavy queries (CREATE, ALTER, etc.) and store it,
+	 * ignoring transients and options by default.
+	 *
+	 * @param string $query The SQL query.
+	 * @return string
+	 */
+	public function maybe_log_query( $query ) {
+		global $wpdb;
+
+		if ( ! preg_match( '/^\s*(create|alter|truncate|drop|insert|delete|update|replace)\s/i', $query ) ) {
+			return $query;
+		}
+
+		if ( false !== strpos( $query, 'transient_' ) ) {
+			return $query;
+		}
+
+		if ( false !== strpos( $query, $wpdb->options ) ) {
+			return $query;
+		}
+
+		if ( apply_filters( 'tenup_experience_log_query', true, $query ) ) {
+			$this->log_query( $query );
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Get the logged queries. Also removes from the transient all queries logged for more than 7 days.
+	 *
+	 * @return array
+	 */
+	public function get_report() {
+		$date_limit = strtotime( '7 days ago' );
+
+		$stored_queries = array_filter(
+			(array) get_transient( self::TRANSIENT_NAME ),
+			function ( $query_date ) use ( $date_limit ) {
+				return strtotime( $query_date ) > $date_limit;
+			},
+			ARRAY_FILTER_USE_KEY
+		);
+
+		set_transient( self::TRANSIENT_NAME, $stored_queries );
+
+		return $stored_queries;
+	}
+
+	/**
+	 * Log/store a SQL query
+	 *
+	 * Queries are stored like:
+	 *
+	 *    'YYYY-MM-DD' => [
+	 *        'a5be998feee8968155052c4d332a7223' => [ // md5 of file:line:query
+	 *            'query' => 'ALTER TABLE wp_my_db_heavy_plugin CHANGE COLUMN `id` id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT',
+	 *            'file' => '/var/www/html/wp-content/plugins/my-db-heavy-plugin/my-db-heavy-plugin.php',
+	 *            'line' => 53,
+	 *            'count' => 1,
+	 *        ]
+	 *    ]
+	 *
+	 * @param string $query The SQL query.
+	 */
+	protected function log_query( $query ) {
+		static $stored_queries;
+		if ( empty( $stored_queries ) ) {
+			$stored_queries = get_transient( self::TRANSIENT_NAME ) ?? [];
+		}
+
+		$current_date = date_i18n( 'Y-m-d' );
+
+		if ( ! isset( $stored_queries[ $current_date ] ) ) {
+			$stored_queries[ $current_date ] = [];
+		}
+
+		$main_caller = $this->find_main_caller();
+
+		$key = md5(
+			$main_caller['file'] . ':' .
+			$main_caller['line'] . ':' .
+			$query
+		);
+
+		if ( isset( $stored_queries[ $current_date ][ $key ] ) ) {
+			$stored_queries[ $current_date ][ $key ]['count']++;
+		} else {
+			$stored_queries[ $current_date ][ $key ] = [
+				'query' => $query,
+				'file'  => $main_caller['file'],
+				'line'  => $main_caller['line'],
+				'count' => 1,
+			];
+		}
+
+		set_transient( self::TRANSIENT_NAME, $stored_queries );
+	}
+
+	/**
+	 * Based on the debug backtrace, try to find the main caller, i.e., the plugin/theme
+	 * that fired the query.
+	 *
+	 * Simple SQL queries generally come from wp-db.php. dbDelta calls come from upgrade.php.
+	 * We are usually interested in the caller immediately before those.
+	 *
+	 * @return array
+	 */
+	protected function find_main_caller() {
+		$debug_backtrace = debug_backtrace(); // phpcs:ignore
+
+		// Remove this plugin references of the backtrace.
+		array_shift( $debug_backtrace );
+		array_shift( $debug_backtrace );
+
+		$main_caller = null;
+
+		$wp_db_found = false;
+		foreach ( $debug_backtrace as $caller ) {
+			$is_wp_db_file = ( false !== strpos( $caller['file'], 'wp-db.php' ) || false !== strpos( $caller['file'], 'upgrade.php' ) );
+			if ( $is_wp_db_file ) {
+				$wp_db_found = true;
+			}
+			if ( ! $wp_db_found || $is_wp_db_file ) {
+				continue;
+			}
+			$main_caller = $caller;
+			break;
+		}
+
+		// If a caller was not found simply get the first item of the backtrace.
+		if ( ! $main_caller ) {
+			$main_caller = array_shift( $debug_backtrace );
+		}
+
+		return $main_caller;
+	}
+}

--- a/includes/classes/SupportMonitor/DBQueryMonitor.php
+++ b/includes/classes/SupportMonitor/DBQueryMonitor.php
@@ -297,7 +297,7 @@ class DBQueryMonitor {
 			$stored_queries[ $current_date ][ $key ]['count']++;
 		} else {
 			$stored_queries[ $current_date ][ $key ] = [
-				'query' => $query,
+				'query' => $this->escape_query( $query ),
 				'file'  => $main_caller['file'],
 				'line'  => $main_caller['line'],
 				'count' => 1,
@@ -344,6 +344,25 @@ class DBQueryMonitor {
 		}
 
 		return $main_caller;
+	}
+
+	/**
+	 * Escape queries to avoid storing sensitive info.
+	 *
+	 * This function takes INSERTs and UPDATEs and replace all parameter values
+	 * between the `'` and `"` chars with `?`
+	 *
+	 * @param string $query The SQL query.
+	 * @return string
+	 */
+	protected function escape_query( $query ) {
+		if ( ! preg_match( '/UPDATE|INSERT/', $query ) ) {
+			return $query;
+		}
+
+		$query = preg_replace( "/[\"'](.*?)[\"']/", '?', $query );
+
+		return $query;
 	}
 
 	/**

--- a/includes/classes/SupportMonitor/DBQueryMonitor.php
+++ b/includes/classes/SupportMonitor/DBQueryMonitor.php
@@ -122,7 +122,7 @@ class DBQueryMonitor {
 			$stored_queries[ $current_date ][ $key ]['count']++;
 		} else {
 			$stored_queries[ $current_date ][ $key ] = [
-				'query' => $query,
+				'query' => stripslashes( $query ),
 				'file'  => $main_caller['file'],
 				'line'  => $main_caller['line'],
 				'count' => 1,

--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -16,11 +16,21 @@ use TenUpExperience\Singleton;
  */
 class Monitor extends Singleton {
 	/**
+	 * The DBQueryMonitor instance.
+	 *
+	 * @since x.x
+	 * @var DBQueryMonitor
+	 */
+	protected $db_query_monitor;
+
+	/**
 	 * Setup module
 	 *
 	 * @since 1.7
 	 */
 	public function setup() {
+		$this->db_query_monitor = new DBQueryMonitor();
+		$this->db_query_monitor->setup();
 
 		if ( TENUP_EXPERIENCE_IS_NETWORK ) {
 			add_action( 'wpmu_options', [ $this, 'ms_settings' ] );
@@ -461,6 +471,7 @@ class Monitor extends Singleton {
 			$this->format_message(
 				[
 					'php_version' => $this->get_php_version(),
+					'db_queries'  => $this->db_query_monitor->get_report(),
 				],
 				'notice',
 				'system'

--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -470,8 +470,8 @@ class Monitor extends Singleton {
 			),
 			$this->format_message(
 				[
-					'php_version' => $this->get_php_version(),
-					'db_queries'  => $this->db_query_monitor->get_report(),
+					'php_version'          => $this->get_php_version(),
+					'had_heavy_db_queries' => $this->db_query_monitor->get_report(),
 				],
 				'notice',
 				'system'

--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -509,8 +509,7 @@ class Monitor extends Singleton {
 			),
 			$this->format_message(
 				[
-					'php_version'          => $this->get_php_version(),
-					'had_heavy_db_queries' => $this->db_query_monitor->get_report(),
+					'php_version' => $this->get_php_version(),
 				],
 				'notice',
 				'system'
@@ -530,6 +529,14 @@ class Monitor extends Singleton {
 				],
 				'notice',
 				'webvitals'
+			);
+		}
+
+		if ( $this->db_query_monitor->is_enabled() ) {
+			$messages[] = $this->format_message(
+				$this->db_query_monitor->get_report(),
+				'notice',
+				'db_queries'
 			);
 		}
 

--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -89,6 +89,12 @@ class Monitor extends Singleton {
 			$setting['server_url'] = sanitize_text_field( $_POST['tenup_support_monitor_settings']['server_url'] );
 		}
 
+		if ( ! $this->db_query_monitor->is_available() || ! isset( $_POST['tenup_support_monitor_settings']['enable_db_query_monitor'] ) ) {
+			$setting['enable_db_query_monitor'] = 'no';
+		} else {
+			$setting['enable_db_query_monitor'] = sanitize_text_field( $_POST['tenup_support_monitor_settings']['enable_db_query_monitor'] );
+		}
+
 		update_site_option( 'tenup_support_monitor_settings', $setting );
 	}
 
@@ -134,6 +140,14 @@ class Monitor extends Singleton {
 						</td>
 					</tr>
 				<?php endif; ?>
+				<?php if ( $this->db_query_monitor->is_available() ) : ?>
+					<tr>
+						<th scope="row"><?php esc_html_e( 'DB Query Monitor', 'tenup' ); ?></th>
+						<td>
+							<?php $this->enable_db_query_monitor_field(); ?>
+						</td>
+					</tr>
+				<?php endif; ?>
 			</tbody>
 		</table>
 		<?php
@@ -148,10 +162,11 @@ class Monitor extends Singleton {
 	 */
 	public function get_setting( $setting_key = null ) {
 		$defaults = [
-			'enable_support_monitor' => 'no',
-			'api_key'                => '',
-			'server_url'             => 'https://supportmonitor.10up.com',
-			'production_environment' => 'no',
+			'enable_support_monitor'  => 'no',
+			'api_key'                 => '',
+			'server_url'              => 'https://supportmonitor.10up.com',
+			'production_environment'  => 'no',
+			'enable_db_query_monitor' => 'no',
 		];
 
 		$settings = ( TENUP_EXPERIENCE_IS_NETWORK ) ? get_site_option( 'tenup_support_monitor_settings', [] ) : get_option( 'tenup_support_monitor_settings', [] );
@@ -277,6 +292,15 @@ class Monitor extends Singleton {
 			);
 		}
 
+		if ( $this->db_query_monitor->is_available() ) {
+			add_settings_field(
+				'enable_db_query_monitor',
+				esc_html__( 'DB Query Monitor', 'tenup' ),
+				[ $this, 'enable_db_query_monitor_field' ],
+				'general',
+				'tenup_support_monitor'
+			);
+		}
 	}
 
 	/**
@@ -345,6 +369,21 @@ class Monitor extends Singleton {
 		<?php
 	}
 
+	/**
+	 * Output production environment field
+	 *
+	 * @since x.x
+	 */
+	public function enable_db_query_monitor_field() {
+		$value = $this->get_setting( 'enable_db_query_monitor' );
+		?>
+		<input name="tenup_support_monitor_settings[enable_db_query_monitor]" <?php checked( 'yes', $value ); ?> type="radio" id="tenup_enable_db_query_monitor_yes" value="yes"> <label for="tenup_enable_db_query_monitor_yes"><?php esc_html_e( 'Yes', 'tenup' ); ?></label><br>
+		<input name="tenup_support_monitor_settings[enable_db_query_monitor]" <?php checked( 'no', $value ); ?> type="radio" id="tenup_enable_db_query_monitor_no" value="no"> <label for="tenup_enable_db_query_monitor_no"><?php esc_html_e( 'No', 'tenup' ); ?></label>
+		<p class="description">
+			<?php esc_html_e( 'Log heavy SQL queries. For performance reasons, only available in non-production environments.', 'tenup' ); ?>
+		</p>
+		<?php
+	}
 
 	/**
 	 * Sends a message async one time


### PR DESCRIPTION
### Description of the Change

This PR adds a "submodule" to Support Monitor, logging, and sending heavy SQL queries.

It also remove some `instance()->setup()` calls, as `instance()` already calls `setup()` in its first execution (what was causing hooks to be added twice.)

### Benefits

While updating plugins on staging we can detect any major changes in the database structure, so we can plan accordingly the same changes for production.

### Verification Process

1. Installed the plugin in a WordPress test installation
2. Installed Support Monitor in another WP test install
3. Checked messages in the "system" group coming

### Changelog Entry

Added: DB Query Monitor