### PR TITLE
Fix check mbstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@
   By default, all users must use a medium or greater strength password. This can be turned off in general settings (or network settings if network activated). Reserved usernames such as `admin` are prevented from being used.
 
 	*Configured in `Settings > General` or `Settings > Network Settings` if network activated.*
+  
+  **Password strength functionality requires the PHP extension [mbstring](https://www.php.net/manual/en/mbstring.installation.php) to be installed on the web server. Functionality will be bypassed if extension not installed.*
+
 
 * __Headers__
 

--- a/includes/classes/Authentication/Passwords.php
+++ b/includes/classes/Authentication/Passwords.php
@@ -316,13 +316,16 @@ class Passwords extends Singleton {
 
 		// Enforce?
 		if ( $enforce ) {
-			$zxcvbn = new Zxcvbn();
+			// Zxcbn requires the mbstring PHP extension, so we'll need to check for it before using
+			if ( function_exists( 'mb_ord' ) ) {
+				$zxcvbn = new Zxcvbn();
 
-			$pw = $zxcvbn->passwordStrength( $_POST['pass1'] );
-
-			if ( 3 > (int) $pw['score'] ) {
-				$password_ok = false;
-			}
+				$pw = $zxcvbn->passwordStrength( $_POST['pass1'] );
+	
+				if ( 3 > (int) $pw['score'] ) {
+					$password_ok = false;
+				}
+			}			
 		}
 
 		if ( ! $password_ok && is_wp_error( $errors ) ) {


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

Addresses issue https://github.com/10up/10up-experience/issues/80 where a fatal error occurred during saving a profile if the mbstring PHP extension wasn't installed on the server.

Checks for mbstring function before trying to use the external dependency Zxcvbn, which was causing the issue.

Also adds documentation to let users know about the mbstring extension requirement in the README for password strength checker to work.

### Verification Process
- Disabled mbstring extension in local PHP environment
- Saved profile on master branch with extension disabled and verified fatal error occurs.
- Switched to branch with fixes
- Saved profile and verified fatal didn't appear.
