### PR TITLE
Add parent menu slug to `add_submenu_page` to avoid PHP 8.2 deprecation notices

### DIFF
--- a/includes/classes/AdminCustomizations/Customizations.php
+++ b/includes/classes/AdminCustomizations/Customizations.php
@@ -34,7 +34,7 @@ class Customizations {
 	 * Register admin pages with output callbacks
 	 */
 	public function register_admin_pages() {
-		add_submenu_page( null, esc_html__( 'About 10up', 'tenup' ), esc_html__( 'About 10up', 'tenup' ), 'edit_posts', '10up-about', [ $this, 'main_screen' ] );
+		add_submenu_page( 'admin.php', esc_html__( 'About 10up', 'tenup' ), esc_html__( 'About 10up', 'tenup' ), 'edit_posts', '10up-about', [ $this, 'main_screen' ] );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
This change fixes PHP 8.2 deprecation notices

```
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /Users/claytoncollie/www/10upexperience/app/public/wp-includes/functions.php on line 7053

Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /Users/claytoncollie/www/10upexperience/app/public/wp-includes/functions.php on line 2165

Deprecated: strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/claytoncollie/www/10upexperience/app/public/wp-admin/admin-header.php on line 36
```

### How to test the Change
1. Create a fresh install of WordPress
2. Clone repository and checkout branch
3. Set `WP_DEBUG` and `WP_DEBUG_DISPLAY` to `true`
4. Visit the wp-admin to look for the errors
5. Make sure you can visit the about 10up screen --> http://localhost:10003/wp-admin/admin.php?page=10up-about 

### Changelog Entry
> Fixed - Passing null as parameter 1. Define the parent menu slug when registering the submenu screen


### Credits
Props @claytoncollie


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
