### PR TITLE
SSO: check that `$REQUEST['redirect_to']` is a string before using it inside the conditional

### DIFF
--- a/includes/classes/SSO/SSO.php
+++ b/includes/classes/SSO/SSO.php
@@ -297,7 +297,7 @@ class SSO {
 			$tenup_login_failed = true;
 		} else {
 			$redirect_url = wp_login_url();
-			if ( isset( $_REQUEST['redirect_to'] ) ) {
+			if ( isset( $_REQUEST['redirect_to'] ) && is_string( $_REQUEST['redirect_to'] ) ) {
 				$redirect_url = add_query_arg( 'redirect_to', rawurlencode( $_REQUEST['redirect_to'] ), $redirect_url );
 			}
 


### PR DESCRIPTION
Checks that `$REQUEST['redirect_to']` is a string before using it inside the conditional.

Closes #136 

### How to test the Change
1. Checkout branch in wp-content/plugins directory
2. Activate the plugin
3. Go to the login screen
4. Login with Single Sign On and get into the admin
5. Login with Single Sign On and get rejected

### Changelog Entry
> Fixed - SSO: check that `$REQUEST['redirect_to']` is a string before using it inside the conditional.

### Credits
Props @claytoncollie

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
