### PR TITLE
Fix/autoload options

### DIFF
--- a/includes/classes/SupportMonitor/Debug.php
+++ b/includes/classes/SupportMonitor/Debug.php
@@ -193,7 +193,7 @@ class Debug {
 		if ( TENUP_EXPERIENCE_IS_NETWORK ) {
 			update_site_option( 'tenup_support_monitor_log', $log );
 		} else {
-			update_option( 'tenup_support_monitor_log', $log );
+			update_option( 'tenup_support_monitor_log', $log, false );
 		}
 	}
 

--- a/includes/classes/SupportMonitor/Debug.php
+++ b/includes/classes/SupportMonitor/Debug.php
@@ -190,6 +190,17 @@ class Debug {
 
 		array_unshift( $log, $prepared );
 
+		// If mb_strlen is available, check the size of the log and ensure we keep it under 1mb.
+		if ( function_exists( 'mb_strlen' ) ) {
+			// 1mb in bytes
+			$max_size = apply_filters( 'tenup_support_monitor_max_debug_log_size', 1048576 );
+
+			// If the log is larger than 1mb, remove the oldest entry
+			while ( mb_strlen( serialize( (array) $log ), '8bit' ) > $max_size ) {
+				array_pop( $log );
+			}
+		}
+
 		if ( TENUP_EXPERIENCE_IS_NETWORK ) {
 			update_site_option( 'tenup_support_monitor_log', $log );
 		} else {


### PR DESCRIPTION
### Description of the Change
This update changes the `tenup_support_monitor_log` option to not be part of the autoload options. It also adds some logic to reduce the size of the debug log to ensure it doesn't go over 1mb in total size as that could mess with caching solutions.

The 1mb is changeable via a filter.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #138 

### How to test the Change
See steps in #138 

### Changelog Entry
> Fixed - Issue with autoloaded debug option



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @tott @darylldoyle 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
