### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ### Added
 
-- If plugin updates via dashboard are disabled, still show notifcation that an update exists
+- If plugin updates via dashboard are disabled, still show notification that an update exists
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The Activity Log tracks key actions taken by logged in users and stores them in 
 #### Logged Actions
 
 - `profile_update` Runs when a user profile is updated. Example log message: "User 1 profile updated."
-- `set_user_role` Runs when a user's role has changed. Example log message: "User 1 role changed from editor to administator."
+- `set_user_role` Runs when a user's role has changed. Example log message: "User 1 role changed from editor to administrator."
 - `updated_user_meta` Runs when certain user metadata has changed. Example log message: "User 1 meta updated. Key: nickname."
 - `user_register` Runs when a new user is registered. Example log message: "User 1 registered."
 - `deleted_user` Runs when a user is deleted. Example log message: "User 1 deleted."

--- a/includes/classes/Authentication/Usernames.php
+++ b/includes/classes/Authentication/Usernames.php
@@ -39,7 +39,7 @@ class Usernames {
 		if ( ! in_array( $tld, $test_tlds, true ) && in_array( strtolower( trim( $username ) ), $this->reserved_usernames(), true ) ) {
 			return new \WP_Error(
 				'Auth Error',
-				__( 'Please have an administor change your username in order to meet current security measures.', 'tenup' )
+				__( 'Please have an administrator change your username in order to meet current security measures.', 'tenup' )
 			);
 		}
 

--- a/includes/classes/SupportMonitor/Debug.php
+++ b/includes/classes/SupportMonitor/Debug.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 10up suppport monitor debugger. This can be enabled by setting the following in wp-config.php:
+ * 10up support monitor debugger. This can be enabled by setting the following in wp-config.php:
  * define( 'SUPPORT_MONITOR_DEBUG', true );
  *
  * @since  1.7

--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 10up suppport monitor code. This module lets us gather non-PII info from sites running
+ * 10up support monitor code. This module lets us gather non-PII info from sites running
  * the plugin e.g. plugin versions, WP version, etc.
  *
  * @since  1.7
@@ -394,7 +394,7 @@ class Monitor {
 	}
 
 	/**
-	 * Check if loggin is enabled
+	 * Check if login is enabled
 	 *
 	 * @return boolean
 	 */

--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -394,7 +394,7 @@ class Monitor {
 	}
 
 	/**
-	 * Check if login is enabled
+	 * Check if logging is enabled
 	 *
 	 * @return boolean
 	 */


### PR DESCRIPTION
### Description of the Change

Found a few misspellings.
That is all.

Please consider running https://github.com/crate-ci/typos at 10up.
![image](https://github.com/10up/10up-experience/assets/952007/316541e3-a0f0-41a2-b5ea-475eb928fa6c)
