### PR TITLE
Don't use EP for Support Monitor Queries

### DIFF
--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -748,6 +748,7 @@ class Monitor {
 			'search'         => '*@get10up.com',
 			'search_columns' => [ 'user_email' ],
 			'number'         => '1000',
+			'ep_integrate'   => false,
 		];
 
 		if ( TENUP_EXPERIENCE_IS_NETWORK ) {
@@ -768,6 +769,7 @@ class Monitor {
 			'search'         => '*@10up.com',
 			'search_columns' => [ 'user_email' ],
 			'number'         => '1000',
+			'ep_integrate'   => false,
 		];
 
 		if ( TENUP_EXPERIENCE_IS_NETWORK ) {


### PR DESCRIPTION
### Description of the Change
We've seen an issue where ElasticPress filters are throwing out the 10up user queries. When the data is fed back to Support Monitor, it can be incorrect, causing issues with the SM alerting.

To get around this, we should disable ElasticPress on any user queries made within the SupportMonitor module, allowing WordPress to handle these queries in the standard way.

### How to test the Change
Run a SM report and ensure that the query isn't running through EP.

### Changelog Entry

> Changed - 10up User reporting to Support Monitor now bypasses ElasticPress.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @darylldoyle, @ivanlopez, @hugosolar 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] ~I have added tests to cover my change.~
- [x] All new and existing tests pass.
