### PR TITLE
#161 - Allow defining support monitor constants to override settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ There are 2 filters available here:
 
 - `TENUPSSO_DISABLE` - Define this as `true` to force disable SSO.
 - `TENUPSSO_DISALLOW_ALL_DIRECT_LOGIN` - Define this as `true` to disable username/password log ins completely.
+- `SUPPORT_MONITOR_ENABLE` - Overrides the settings to enable Support Monitor. Possible values `yes` and `no`.
+- `SUPPORT_MONITOR_API_KEY` - Overrides the settings to Support Monitor API key.
+- `SUPPORT_MONITOR_SERVER_URL` - Overrides the settings to Support Monitor server url.
 
 ### Activity Log
 

--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -26,11 +26,9 @@ class Monitor {
 	public function setup() {
 
 		if ( TENUP_EXPERIENCE_IS_NETWORK ) {
-			add_filter( 'site_option_tenup_support_monitor_settings', [ $this, 'handle_settings' ] );
 			add_action( 'wpmu_options', [ $this, 'ms_settings' ] );
 			add_action( 'admin_init', [ $this, 'ms_save_settings' ] );
 		} else {
-			add_filter( 'option_tenup_support_monitor_settings', [ $this, 'handle_settings' ] );
 			add_action( 'admin_init', [ $this, 'register_settings' ] );
 		}
 
@@ -139,8 +137,20 @@ class Monitor {
 		$settings = ( TENUP_EXPERIENCE_IS_NETWORK ) ? get_site_option( 'tenup_support_monitor_settings', [] ) : get_option( 'tenup_support_monitor_settings', [] );
 		$settings = wp_parse_args( $settings, $defaults );
 
-		if ( ! Debug::instance()->is_debug_enabled() && ! defined( 'SUPPORT_MONITOR_SERVER_URL' ) ) {
+		if ( ! Debug::instance()->is_debug_enabled() ) {
 			$settings['server_url'] = 'https://monitor.10up.com';
+		}
+
+		if ( defined( 'SUPPORT_MONITOR_SERVER_URL' ) ) {
+			$settings['server_url'] = SUPPORT_MONITOR_SERVER_URL;
+		}
+
+		if ( defined( 'SUPPORT_MONITOR_API_KEY' ) ) {
+			$settings['api_key'] = SUPPORT_MONITOR_API_KEY;
+		}
+
+		if ( defined( 'SUPPORT_MONITOR_ENABLE' ) ) {
+			$settings['enable_support_monitor'] = SUPPORT_MONITOR_ENABLE;
 		}
 
 		if ( ! empty( $setting_key ) ) {
@@ -161,26 +171,6 @@ class Monitor {
 			<?php esc_html_e( '10up collects data on site health including plugin, WordPress, and system versions as well as general site issues to provide proactive support to your website. No proprietary data or user information is sent back to us. Although recommended, this functionality is optional and can be disabled.', 'tenup' ); ?>
 		</p>
 		<?php
-	}
-
-	/**
-	 * Handle settings.
-	 *
-	 * @param  array $settings Support Monitor Settings.
-	 * @since  1.11.3
-	 * @return array
-	 */
-	public function handle_settings( $settings ) {
-		if ( defined( 'SUPPORT_MONITOR_ENABLE' ) ) {
-			$settings['enable_support_monitor'] = SUPPORT_MONITOR_ENABLE;
-		}
-		if ( defined( 'SUPPORT_MONITOR_API_KEY' ) ) {
-			$settings['api_key'] = SUPPORT_MONITOR_API_KEY;
-		}
-		if ( defined( 'SUPPORT_MONITOR_SERVER_URL' ) ) {
-			$settings['server_url'] = SUPPORT_MONITOR_SERVER_URL;
-		}
-		return $settings;
 	}
 
 	/**
@@ -239,21 +229,6 @@ class Monitor {
 	 * @return array
 	 */
 	public function sanitize_settings( $settings ) {
-		// Attempt to preserve value if using defined constants and if user value was already stored in the DB.
-		if ( defined( 'SUPPORT_MONITOR_ENABLE' ) || defined( 'SUPPORT_MONITOR_SERVER_URL' ) || defined( 'SUPPORT_MONITOR_API_KEY' ) ) {
-			remove_filter( 'option_tenup_support_monitor_settings', [ $this, 'handle_settings' ] );
-			$original = get_option( 'tenup_support_monitor_settings' );
-			if ( defined( 'SUPPORT_MONITOR_ENABLE' ) ) {
-				$settings['enable_support_monitor'] = $original['enable_support_monitor'];
-			}
-			if ( defined( 'SUPPORT_MONITOR_SERVER_URL' ) ) {
-				$settings['server_url'] = $original['server_url'];
-			}
-			if ( defined( 'SUPPORT_MONITOR_API_KEY' ) ) {
-				$settings['api_key'] = $original['api_key'];
-			}
-		}
-
 		foreach ( $settings as $key => $setting ) {
 			$settings[ $key ] = sanitize_text_field( $setting );
 		}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Allow defining support monitor constants to override settings. Support has been added for both network activation and single-site activation.
New constants that were introduced.
1. `SUPPORT_MONITOR_ENABLE`
2. `SUPPORT_MONITOR_API_KEY`
3. `SUPPORT_MONITOR_SERVER_URL`

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #161 

**Default View:**
![image](https://github.com/user-attachments/assets/e27fa570-3b48-4921-8980-e29ef41d899a)

**View with Constants Set**
```php
define( 'SUPPORT_MONITOR_ENABLE', 'yes' );
define( 'SUPPORT_MONITOR_API_KEY', '123123123145' );
define( 'SUPPORT_MONITOR_SERVER_URL', 'https://example.org' );
```
<img width="760" alt="image" src="https://github.com/user-attachments/assets/c9d30658-42d2-40af-8e1e-8479f4f2c01f" />


### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Test out the settings for support monitor settings as part of this plugin on both a network activated multisite installation and a single site installation.
2. Check by defining various combinations of all or some of the constants in the `wp-config.php` and reviewing the Support Monitor Settings. They should replace the user saved values and also not be editable when it is defined.
3. Removing all or any of the constants from the `wp-config.php` should preserve the prior user saved values for the settings.


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New Support Monitor settings constants - `SUPPORT_MONITOR_ENABLE`, `SUPPORT_MONITOR_API_KEY`, `SUPPORT_MONITOR_SERVER_URL`


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @joshuaabenazer, @darylldoyle, @claytoncollie 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
