### PR TITLE
Add tenup_experience_rest_api_allowlist filter for overriding allowed…

### DIFF
--- a/10up-experience.php
+++ b/10up-experience.php
@@ -3,7 +3,7 @@
  * Plugin Name:       10up Experience
  * Plugin URI:        https://github.com/10up/10up-experience
  * Description:       The 10up Experience plugin configures WordPress to better protect and inform clients, aligned to 10up’s best practices.
- * Version:           1.12.0
+ * Version:           1.12.1
  * Author:            10up
  * Author URI:        https://10up.com
  * License:           GPLv2 or later
@@ -19,7 +19,7 @@ namespace TenUpExperience;
 
 use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
 
-define( 'TENUP_EXPERIENCE_VERSION', '1.12.0' );
+define( 'TENUP_EXPERIENCE_VERSION', '1.12.1' );
 define( 'TENUP_EXPERIENCE_DIR', __DIR__ );
 define( 'TENUP_EXPERIENCE_FILE', __FILE__ );
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).
 
+## [1.12.1] - 2024-09-24
+
+- Add filter for allowlisting specific API routes `tenup_experience_rest_api_allowlist`
+
+## [1.12.0] - 2024-08-22
+
+- Add UI for disabling comments
+
 ## [1.11.2] - 2024-06-15
+
 - Remove production setting
 
 ## [1.11.1] - 2023-10-27
@@ -201,7 +210,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 - Initial release
 
-[Unreleased]: https://github.com/10up/10up-experience/compare/master...develop
+[unreleased]: https://github.com/10up/10up-experience/compare/master...develop
 [1.7.3]: https://github.com/10up/10up-experience/compare/1.7.2...1.7.3
 [1.7.2]: https://github.com/10up/10up-experience/compare/1.7.1...1.7.2
 [1.7.1]: https://github.com/10up/10up-experience/compare/1.7...1.7.1

--- a/includes/classes/API/API.php
+++ b/includes/classes/API/API.php
@@ -51,7 +51,7 @@ class API {
 
 		$restrict = get_option( 'tenup_restrict_rest_api', $this->option_default );
 
-		if ( 'all' === $restrict && ! $this->user_can_access_rest_api() ) {
+		if ( 'all' === $restrict && ! $this->can_access_rest_api() ) {
 			return new \WP_Error( 'rest_api_restricted', esc_html__( 'Authentication Required', 'tenup' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
@@ -71,7 +71,7 @@ class API {
 			return $endpoints;
 		}
 
-		if ( ! $this->user_can_access_rest_api() ) {
+		if ( ! $this->can_access_rest_api() ) {
 			$keys = preg_grep( '/\/wp\/v2\/users\b/', array_keys( $endpoints ) );
 
 			foreach ( $keys as $key ) {
@@ -143,8 +143,18 @@ class API {
 	 * @param  int $user_id User ID
 	 * @return bool         Whether the given user can access the REST API
 	 */
-	public function user_can_access_rest_api( $user_id = 0 ) {
-		return is_user_logged_in();
+	public function can_access_rest_api( $user_id = 0 ) {
+		global $wp;
+
+		$route = '';
+
+		if ( isset( $wp->query_vars['rest_route'] ) ) {
+			$route = $wp->query_vars['rest_route'];
+		}
+
+		$allowed_rest_routes_override = apply_filters( 'tenup_experience_rest_api_allowlist', [] );
+
+		return is_user_logged_in() || in_array( $route, $allowed_rest_routes_override, true );
 	}
 
 	/**


### PR DESCRIPTION
Add a filter `tenup_experience_rest_api_allowlist` to allow developers to allowlist specific REST urls when the REST API is set to require authentication.