### PR TITLE
Check haveibeenpwned API during password reset and account creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ By default, all users must use a medium or greater strength password. This can b
 
  **Password strength functionality requires the PHP extension [mbstring](https://www.php.net/manual/en/mbstring.installation.php) to be installed on the web server. Functionality will be bypassed if extension not installed.*
 
+Additionally, the plugin checks passwords against the [Have I Been Pwned](https://haveibeenpwned.com/) database to ensure they haven't been compromised in a data breach. This can be disabled by defining the constant `TENUP_EXPERIENCE_DISABLE_HIBP` as `true`.
+
+#### Constants
+
+- `TENUP_EXPERIENCE_DISABLE_HIBP`
+
+Define `TENUP_EXPERIENCE_DISABLE_HIBP` as `true` to disable Have I Been Pwned password checking.
+
 
 ### Headers
 


### PR DESCRIPTION
### Description of the Change

Verify new password against the [Have I Been Pwned API](https://haveibeenpwned.com/API/v3) during password change (on profile or via reset process)

Closes [#77](https://github.com/10up/10up-experience/issues/77)

### How to test the Change

**Changing password through profile**

1. Login to WP and access you profile
2. Scroll down to "Set New Password" and enter something in a breach (e.g. `london123`)
3. Scroll down to the "Update Profile" button
4. If need be, remove the `disabled` attribute on the Update Profile button - this is added through JS when a "weak" password is identified
5. Save and confirm you see the error: "The password entered may have been included in a data breach and is not considered safe to use. Please choose another." - note you may also see another error stating "Password must be medium strength or greater." (ignore this, but be aware of correlation between weak passwords and data breaches, in many cases both errors will show

**Reset password process**

1. Navigate to WP login and run through the password reset process
2. Open the link in the email
3. In the new password field enter something in a breach (e.g. `london123`)
4. If need be, remove the `disabled` attribute on the Save Password button - this is added through JS when a "weak" password is identified
5. Save and confirm you see the error: "The password entered may have been included in a data breach and is not considered safe to use. Please choose another." - note you may also see another error stating "Password must be medium strength or greater." (ignore this, but be aware of correlation between weak passwords and data breaches, in many cases both errors will show


### Changelog Entry

> Added - Verify new password against the [Have I Been Pwned API](https://haveibeenpwned.com/API/v3) during password change (on profile or via reset process)

### Credits
Props @jamesmorrison

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
