### PR TITLE
Don’t render the plugin update notices on VIP as they’re duplicated

### DIFF
--- a/includes/classes/Plugins/Plugins.php
+++ b/includes/classes/Plugins/Plugins.php
@@ -172,6 +172,18 @@ class Plugins {
 	 * constant it is not possible to update any plugin.
 	 */
 	public function set_plugin_update_actions() {
+
+		/**
+		 * VIP has it's own update notification system that performs this same logic.
+		 *
+		 * As such, if we're on a VIP environment, we should not run this logic.
+		 *
+		 * See: https://github.com/Automattic/vip-go-mu-plugins/blob/develop/codebase-manager/plugins/plugins-manager.php#L65-L77
+		 */
+		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+			return;
+		}
+
 		$plugins = get_site_transient( 'update_plugins' );
 
 		if ( isset( $plugins->response ) && is_array( $plugins->response ) ) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
VIP have their own plugin update notification notifications, see: https://github.com/Automattic/vip-go-mu-plugins/blob/develop/codebase-manager/plugins/plugins-manager.php#L65-L77

As they run theirs on the same hook as us, it results in duplicate notices being shown. As such, we should bail early from our logic and use theirs.

**Before**

![image](https://github.com/user-attachments/assets/0aa3e7a4-4d37-41c1-8177-c72dbc28cb83)

**After**

![image](https://github.com/user-attachments/assets/4cc0e5fd-b6b7-4544-84aa-e1083c223fdc)


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #160

### How to test the Change
Ensure that update notices are only shown once on VIP sites.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
* Fixed - Issue with duplicate update notices in VIP.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @darylldoyle 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
