### PR TITLE
🐛 Fix issue with VIP environments

### DIFF
--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -759,6 +759,11 @@ class Monitor {
 			return true;
 		}
 
+		// If this is a VIP site, we can assume they are using an object cache.
+		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'local' !== VIP_GO_APP_ENVIRONMENT ) {
+			return true;
+		}
+
 		return file_exists( WP_CONTENT_DIR . '/object-cache.php' );
 	}
 }


### PR DESCRIPTION
### Description of the Change

VIP environments return `false` for object cache, causing Monitor to flag them as failing. Since VIP is a managed host that always has object caching enabled, we can safely return true if we can confirm that it’s a VIP env. This can be done via the VIP_GO_APP_ENVIRONMENT const as per https://docs.wpvip.com/infrastructure/environments/environment-specific-code/


### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
* Fixed - Issue with cache returning false on VIP environments.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @darylldoyle, @joshuaabenazer 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
