### PR TITLE
Disable Monitor when working on a local environment

### DIFF
--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -141,6 +141,11 @@ class Monitor {
 			$settings['server_url'] = 'https://monitor.10up.com';
 		}
 
+		// Disable support monitor for local environments to prevent polluting monitor with .test/.local domains
+		if ( $this->is_local_environment() ) {
+			$settings['enable_support_monitor'] = 'no';
+		}
+
 		if ( defined( 'SUPPORT_MONITOR_SERVER_URL' ) ) {
 			$settings['server_url'] = SUPPORT_MONITOR_SERVER_URL;
 		}
@@ -161,6 +166,16 @@ class Monitor {
 	}
 
 	/**
+	 * Check if we're in a local environment
+	 *
+	 * @since 2.1
+	 * @return bool
+	 */
+	public function is_local_environment() {
+		return function_exists( 'wp_get_environment_type' ) && 'local' === wp_get_environment_type();
+	}
+
+	/**
 	 * Output setting section description
 	 *
 	 * @since 1.7
@@ -170,6 +185,16 @@ class Monitor {
 		<p>
 			<?php esc_html_e( '10up collects data on site health including plugin, WordPress, and system versions as well as general site issues to provide proactive support to your website. No proprietary data or user information is sent back to us. Although recommended, this functionality is optional and can be disabled.', 'tenup' ); ?>
 		</p>
+		<?php if ( $this->is_local_environment() ) : ?>
+			<div class="notice notice-info inline">
+				<p>
+					<strong>
+						<?php esc_html_e( 'Local Environment Detected:', 'tenup' ); ?>
+					</strong>
+					<?php esc_html_e( 'Support monitoring is automatically disabled in local environments to prevent test/development data from being sent to the monitoring service.', 'tenup' ); ?>
+				</p>
+			</div>
+		<?php endif; ?>
 		<?php
 	}
 
@@ -244,8 +269,8 @@ class Monitor {
 	public function enable_field() {
 		$value = $this->get_setting( 'enable_support_monitor' );
 		?>
-		<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'yes', $value ); ?><?php disabled( defined( 'SUPPORT_MONITOR_ENABLE' ) ); ?> type="radio" id="tenup_enable_support_monitor_yes" value="yes"> <label for="tenup_enable_support_monitor_yes"><?php esc_html_e( 'Yes', 'tenup' ); ?></label><br>
-		<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'no', $value ); ?><?php disabled( defined( 'SUPPORT_MONITOR_ENABLE' ) ); ?> type="radio" id="tenup_enable_support_monitor_no" value="no"> <label for="tenup_enable_support_monitor_no"><?php esc_html_e( 'No', 'tenup' ); ?></label>
+		<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'yes', $value ); ?><?php disabled( defined( 'SUPPORT_MONITOR_ENABLE' ) || $this->is_local_environment() ); ?> type="radio" id="tenup_enable_support_monitor_yes" value="yes"> <label for="tenup_enable_support_monitor_yes"><?php esc_html_e( 'Yes', 'tenup' ); ?></label><br>
+		<input name="tenup_support_monitor_settings[enable_support_monitor]" <?php checked( 'no', $value ); ?><?php disabled( defined( 'SUPPORT_MONITOR_ENABLE' ) || $this->is_local_environment() ); ?> type="radio" id="tenup_enable_support_monitor_no" value="no"> <label for="tenup_enable_support_monitor_no"><?php esc_html_e( 'No', 'tenup' ); ?></label>
 		<?php
 	}
 


### PR DESCRIPTION
This PR will disable reporting when working on a `local` environment accoriding to the `wp_get_environment_type()` value. This change will prevent `.test` and `.local` domains from polluting Support Monitor.

Closes #180 

### Changelog Entry
> Added - Disable Monitor reporting when working on a local environment

### Credits
Props @claytoncollie 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
