### PR TITLE
Make sure user roles are unindexed arrays

### DIFF
--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -700,7 +700,7 @@ class Monitor {
 			$users[] = [
 				'email' => $user->user_email,
 				'name'  => $user->display_name,
-				'role'  => $user->roles,
+				'role'  => array_values( $user->roles ),
 			];
 		}
 
@@ -721,7 +721,7 @@ class Monitor {
 			$users[] = [
 				'email' => $user->user_email,
 				'name'  => $user->display_name,
-				'role'  => $user->roles,
+				'role'  => array_values( $user->roles ),
 			];
 		}
 
@@ -742,7 +742,7 @@ class Monitor {
 			$users[] = [
 				'email' => $user->user_email,
 				'name'  => $user->display_name,
-				'role'  => $user->roles,
+				'role'  => array_values( $user->roles ),
 			];
 		}
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR makes sure user roles are sent as arrays that have a numeric sequence of indices.

When we convert arrays that don't have sequential numbers as indices to JSON, they become objects instead. For example:

```php
json_encode( [ '0' => 'a', '1' => 'b' ] ); // ["a","b"] - still an array
json_encode( [ '1' => 'b' ] ); // {"1":"b"} - now it is an object
```

It creates a problem when we receive that in Monitor, as the system expects an array.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Ensure user rules are always sequentially numbered arrays

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
