### PR TITLE
Document the REST API allowed route filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,38 @@ Adds an option to general settings to restrict REST API access. The options are:
 
 *Configured in `Settings > Reading`.*
 
+#### Filters
+
+- `tenup_experience_rest_api_allowlist`
+
+Allows specific REST API routes to bypass authentication requirements. This is useful when you need certain endpoints to be publicly accessible while keeping the rest of the API restricted.
+
+**Parameters:**
+- `$allowed_routes` (array) - An array of REST API routes that should be publicly accessible. Default is an empty array.
+
+**Example: Allow a single route**
+
+```php
+add_filter( 'tenup_experience_rest_api_allowlist', function( $allowed_routes ) {
+    $allowed_routes[] = '/wp/v2/posts';
+    return $allowed_routes;
+} );
+```
+
+**Example: Allow multiple routes**
+
+```php
+add_filter( 'tenup_experience_rest_api_allowlist', function( $allowed_routes ) {
+    return array_merge( $allowed_routes, [
+        '/wp/v2/posts',
+        '/wp/v2/pages',
+        '/my-plugin/v1/public-endpoint',
+    ] );
+} );
+```
+
+**Note:** Routes must match exactly as they appear in the REST API. You can find the route for an endpoint by examining the `rest_route` query variable or by checking the REST API documentation.
+
 ### Authors
 
 Removes 10up user author archives so they aren't mistakenly indexed by search engines.

--- a/includes/classes/API/API.php
+++ b/includes/classes/API/API.php
@@ -152,6 +152,17 @@ class API {
 			$route = $wp->query_vars['rest_route'];
 		}
 
+		/**
+		 * Filter the allowed REST API routes.
+		 *
+		 * By default, no routes are allowed.
+		 *
+		 * @link https://developer.wordpress.org/rest-api/reference/routes/
+		 *
+		 * @param array<string> $allowed_rest_routes_override The allowed REST API routes.
+		 *
+		 * @return array<string> The allowed REST API routes.
+		 */
 		$allowed_rest_routes_override = apply_filters( 'tenup_experience_rest_api_allowlist', [] );
 
 		return is_user_logged_in() || in_array( $route, $allowed_rest_routes_override, true );

--- a/includes/classes/API/API.php
+++ b/includes/classes/API/API.php
@@ -153,9 +153,9 @@ class API {
 		}
 
 		/**
-		 * Filter the allowed REST API routes.
-		 *
-		 * By default, no routes are allowed.
+		 * Filter the REST API routes that unauthenticated users can access.
+ 		 *
+		 * By default, for unauthenticated users, no routes are allowed.
 		 *
 		 * @link https://developer.wordpress.org/rest-api/reference/routes/
 		 *

--- a/includes/classes/API/API.php
+++ b/includes/classes/API/API.php
@@ -154,7 +154,7 @@ class API {
 
 		/**
 		 * Filter the REST API routes that unauthenticated users can access.
- 		 *
+		 *
 		 * By default, for unauthenticated users, no routes are allowed.
 		 *
 		 * @link https://developer.wordpress.org/rest-api/reference/routes/


### PR DESCRIPTION
This PR adds documentation for the `tenup_experience_rest_api_allowlist` filter that was introduced in PR #168 (v1.12.1). The filter allows engineers to specify REST API routes that should bypass authentication requirements, making them publicly accessible even when the REST API is restricted to authenticated users.

**Changes included:**

1. **README documentation** - Added a new "Filters" subsection under the REST API section with:
   - Filter name and description
   - Parameter documentation
   - Two practical code examples (single route and multiple routes)
   - A note about exact route matching requirements

2. **Docblock enhancement** - The filter in `API.php` includes a comprehensive docblock with:
   - Description of the filter's purpose
   - Link to WordPress REST API routes documentation
   - Parameter and return type annotations

Closes #169 

### How to test the Change

1. Review the README.md file and verify the new documentation under the "REST API" section is clear and accurate
2. Verify the code examples are syntactically correct PHP
3. Test the filter functionality:
   - Set REST API restriction to "Restrict all access to authenticated users" in Settings > Reading
   - Attempt to access `/wp-json/wp/v2/posts` as an unauthenticated user (should return 401)
   - Add the filter from the example to your theme's `functions.php`:
     ```php
     add_filter( 'tenup_experience_rest_api_allowlist', function( $allowed_routes ) {
         $allowed_routes[] = '/wp/v2/posts';
         return $allowed_routes;
     } );
     ```
   - Access `/wp-json/wp/v2/posts` again as an unauthenticated user (should now return posts)

### Changelog Entry

> Developer - Added documentation for the `tenup_experience_rest_api_allowlist` filter in README.md

### Credits

Props @claytoncollie

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.