### PR TITLE
Fix: pass eslint flags to linting action to ignore `dist/**` & use correct config file

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,7 @@ jobs:
         uses: reviewdog/action-eslint@v1
         with:
           reporter: github-pr-review
+          eslint_flags: "--config .eslintrc.js --ignore-pattern 'dist/**'"
           fail_on_error: true
   phpcs:
     name: phpcs


### PR DESCRIPTION
This pull request makes a minor update to the ESLint workflow configuration. The change ensures that the linter uses the correct configuration file and ignores the `dist` directory during linting.


Closes #201 