### PR TITLE
Fix: Duplicate plugins menu item in admin

### DIFF
--- a/includes/classes/Plugins/Plugins.php
+++ b/includes/classes/Plugins/Plugins.php
@@ -302,8 +302,15 @@ class Plugins {
 			number_format_i18n( $update_data['counts']['plugins'] )
 		);
 
-		// Ensure the core Plugins menu item is set to the correct index.
-		if ( isset( $menu[ $menu_index ][0] ) && ! preg_match( '#^' . esc_html__( 'Plugins' ) . '#i', $menu[ $menu_index ][0] ) ) {
+		$menu_item_exists = isset( $menu[ $menu_index ][0] );
+
+		if ( ! $menu_item_exists ) {
+			return;
+		}
+
+		$is_plugins_menu = preg_match( '#^' . esc_html__( 'Plugins' ) . '#i', $menu[ $menu_index ][0] );
+
+		if ( ! $is_plugins_menu ) {
 			return;
 		}
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #203

> With a certain condition met, two Plugins menu items will appear in the admin sidebar. The duplicate one will have no icon or url. When you collapse the menu, the blank menu item will cover up to uncollapse button, leaving editors stuck in collapsed mode.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
First, follow the steps in #203 to reproduce the duplicate plugin item issue. Then, merge this code in locally, and confirm the duplicate item is no longer being added.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Duplicate plugins menu item in admin

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ZacharyRener 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
