### PR TITLE
Fix SSO button display in RTL

### DIFF
--- a/includes/classes/SSO/SSO.php
+++ b/includes/classes/SSO/SSO.php
@@ -439,6 +439,10 @@ class SSO {
 				transition-timing-function: ease-out;
 			}
 
+			.rtl .sso .button {
+				padding-left: 16px;
+			}
+
 			.sso .button img {
 				height: 32px;
 				width: 32px;


### PR DESCRIPTION
### Description of the Change
Fixes the SSO login button layout when the site uses RTL (right-to-left) by adding RTL-specific padding.

The SSO button uses asymmetric padding (`4px 14px 4px 4px`) so the icon sits correctly in LTR. In RTL, that same padding caused incorrect spacing.

**Benefits:** Correct appearance and usability of the SSO button for RTL languages and RTL themes.
Before:
<img width="432" height="511" alt="image" src="https://github.com/user-attachments/assets/bcd8f62a-8b54-4039-aa33-0042946d39b9" />

After:
<img width="475" height="561" alt="image" src="https://github.com/user-attachments/assets/d7a603ad-b298-456a-b55e-0c9f06e89b73" />


### How to test the Change
1. Open the WordPress login page (e.g. `/wp-login.php`) with the 10up Experience plugin active and SSO enabled.
2. **LTR:** Confirm the SSO ("Sign in with 10up" / Google) button looks and aligns as before.
3. **RTL:** Force RTL (e.g. in DevTools set `document.documentElement.dir = 'rtl'` or use an RTL theme/locale) and reload the login page.
4. Confirm the SSO button has even padding and the icon and label are not clipped or misaligned.

### Changelog Entry
> Fixed - SSO login button padding in RTL so the button displays correctly for right-to-left languages and layouts.

### Credits
Props @psorensen 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.