### PR TITLE
Add hosting provider detection, multisite flag, and user profile URLs

### DIFF
--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -448,7 +448,7 @@ class Monitor {
 			],
 			[
 				'key'   => 'db_version',
-				'value' => ( isset( $wpdb->db_version ) ) ? $wpdb->db_version : '',
+				'value' => $wpdb->db_version() ?: '',
 				'group' => 'system',
 			],
 			[
@@ -464,6 +464,16 @@ class Monitor {
 			[
 				'key'   => 'xmlrpc_enabled',
 				'value' => $this->xmlrpc_enabled(),
+				'group' => 'system',
+			],
+			[
+				'key'   => 'hosting_provider',
+				'value' => $this->get_hosting_provider(),
+				'group' => 'system',
+			],
+			[
+				'key'   => 'is_multisite',
+				'value' => is_multisite(),
 				'group' => 'system',
 			],
 		];
@@ -706,7 +716,8 @@ class Monitor {
 	 * @return array
 	 */
 	public function get_users() {
-		$users = [];
+		$users    = [];
+		$users_url = is_multisite() ? network_admin_url( 'users.php' ) : admin_url( 'users.php' );
 
 		$args = [
 			'search'         => '*@get10up.com',
@@ -723,9 +734,10 @@ class Monitor {
 
 		foreach ( $_users as $user ) {
 			$users[] = [
-				'email' => $user->user_email,
-				'name'  => $user->display_name,
-				'role'  => array_values( $user->roles ),
+				'email'      => $user->user_email,
+				'name'       => $user->display_name,
+				'role'       => array_values( $user->roles ),
+				'profileUrl' => add_query_arg( 's', $user->user_email, $users_url ),
 			];
 		}
 
@@ -744,9 +756,10 @@ class Monitor {
 
 		foreach ( $_users as $user ) {
 			$users[] = [
-				'email' => $user->user_email,
-				'name'  => $user->display_name,
-				'role'  => array_values( $user->roles ),
+				'email'      => $user->user_email,
+				'name'       => $user->display_name,
+				'role'       => array_values( $user->roles ),
+				'profileUrl' => add_query_arg( 's', $user->user_email, $users_url ),
 			];
 		}
 
@@ -765,13 +778,52 @@ class Monitor {
 
 		foreach ( $_users as $user ) {
 			$users[] = [
-				'email' => $user->user_email,
-				'name'  => $user->display_name,
-				'role'  => array_values( $user->roles ),
+				'email'      => $user->user_email,
+				'name'       => $user->display_name,
+				'role'       => array_values( $user->roles ),
+				'profileUrl' => add_query_arg( 's', $user->user_email, $users_url ),
 			];
 		}
 
 		return $users;
+	}
+
+	/**
+	 * Detect the hosting provider based on platform-specific PHP constants.
+	 *
+	 * @since 2.2
+	 * @return string Hosting provider slug (e.g. 'vip', 'kinsta') or 'unknown'.
+	 */
+	public function get_hosting_provider() {
+		if ( defined( 'WPCOM_IS_VIP_ENV' ) || defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+			return 'vip';
+		}
+
+		if ( defined( 'KINSTA_DEV_ENV' ) || defined( 'KINSTA_CACHE_ZONE' ) ) {
+			return 'kinsta';
+		}
+
+		if ( defined( 'WPE_APIKEY' ) || defined( 'IS_WPE' ) ) {
+			return 'wpengine';
+		}
+
+		if ( defined( 'PANTHEON_ENVIRONMENT' ) ) {
+			return 'pantheon';
+		}
+
+		if ( defined( 'STARTER_STARTER' ) || defined( 'JEEVES_ENV' ) ) {
+			return 'pagely';
+		}
+
+		if ( defined( 'FLYWHEEL_CONFIG_DIR' ) ) {
+			return 'flywheel';
+		}
+
+		if ( defined( 'CLOUDWAYS_SERVER_ID' ) ) {
+			return 'cloudways';
+		}
+
+		return 'unknown';
 	}
 
 	/**
@@ -785,7 +837,7 @@ class Monitor {
 		}
 
 		// If this is a VIP site, we can assume they are using an object cache.
-		if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'local' !== VIP_GO_APP_ENVIRONMENT ) {
+		if ( 'vip' === $this->get_hosting_provider() ) {
 			return true;
 		}
 

--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -448,7 +448,7 @@ class Monitor {
 			],
 			[
 				'key'   => 'db_version',
-				'value' => $wpdb->db_version() ?: '',
+				'value' => $wpdb->db_version() ? $wpdb->db_version() : '',
 				'group' => 'system',
 			],
 			[
@@ -716,7 +716,7 @@ class Monitor {
 	 * @return array
 	 */
 	public function get_users() {
-		$users    = [];
+		$users     = [];
 		$users_url = is_multisite() ? network_admin_url( 'users.php' ) : admin_url( 'users.php' );
 
 		$args = [

--- a/includes/classes/SupportMonitor/Monitor.php
+++ b/includes/classes/SupportMonitor/Monitor.php
@@ -466,25 +466,17 @@ class Monitor {
 				'value' => $this->xmlrpc_enabled(),
 				'group' => 'system',
 			],
-			[
-				'key'   => 'hosting_provider',
-				'value' => $this->get_hosting_provider(),
-				'group' => 'system',
-			],
-			[
-				'key'   => 'is_multisite',
-				'value' => is_multisite(),
-				'group' => 'system',
-			],
 		];
 
 		$body = [
-			'url'          => TENUP_EXPERIENCE_IS_NETWORK ? network_home_url() : home_url(),
-			'platform'     => 'wordpress',
-			'packages'     => $this->get_packages(),
-			'activityLogs' => $logs,
-			'customData'   => $custom_data,
-			'users'        => $this->get_users(),
+			'url'             => TENUP_EXPERIENCE_IS_NETWORK ? network_home_url() : home_url(),
+			'platform'        => 'wordpress',
+			'hostingProvider' => $this->get_hosting_provider(),
+			'isMultisite'     => is_multisite(),
+			'packages'        => $this->get_packages(),
+			'activityLogs'    => $logs,
+			'customData'      => $custom_data,
+			'users'           => $this->get_users(),
 		];
 
 		$this->send_request( $body );


### PR DESCRIPTION
## Summary
- Add `get_hosting_provider()` method that auto-detects hosting platform via PHP constants (VIP, Kinsta, WP Engine, Pantheon, Pagely, Flywheel, Cloudways)
- Refactor `get_is_using_object_cache()` VIP check to use centralized hosting detection
- Send `hosting_provider` and `is_multisite` in report 
- Send `profileUrl` (wp-admin user search URL) for each user in `get_users()`
- Fix `db_version` — was checking a non-existent `$wpdb->db_version` property instead of calling `$wpdb->db_version()`

Closes #205

## Test plan
- [ ] Trigger a report via `wp cron event run send_daily_report_cron`
- [ ] Verify `hosting_provider` appears in report (value depends on host; `unknown` on generic hosting)
- [ ] Verify `is_multisite` appears in report (`true` on multisite, `false` on single site)
- [ ] Verify each user entry includes `profileUrl` with a wp-admin search URL
- [ ] Verify `db_version` is now populated (e.g. `8.0.39`) instead of empty
- [ ] Test hosting detection by temporarily defining a host constant (e.g. `define('KINSTA_DEV_ENV', true)`) and confirming the correct provider is returned
- [ ] On a VIP environment, verify `get_is_using_object_cache()` still returns `true` via the refactored check