### PR TITLE
Add .eslintignore to replace CI-only ignore flags

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+vendor/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,6 @@ jobs:
         uses: reviewdog/action-eslint@v1
         with:
           reporter: github-pr-review
-          eslint_flags: "--config .eslintrc.js --ignore-pattern 'dist/**'"
           fail_on_error: true
   phpcs:
     name: phpcs


### PR DESCRIPTION
- Adds `.eslintignore` with `dist/`, `node_modules/`, and `vendor/` so ESLint ignores build artifacts everywhere — CI, pre-commit hooks, and local `npm run lint-js`
- Removes the `eslint_flags` line from the lint workflow (now redundant), including the `--config .eslintrc.js` flag that ESLint auto-discovers

Resolves #201
Builds on #202