### PR TITLE
Fix disabled block allowlist handling

### DIFF
--- a/includes/classes/Comments/Comments.php
+++ b/includes/classes/Comments/Comments.php
@@ -406,9 +406,9 @@ class Comments {
 	/**
 	 * Remove the comment blocks
 	 *
-	 * @param array $allowed_block_types Array of allowed block types.
+	 * @param bool|string[] $allowed_block_types Array of block type slugs, or boolean to enable/disable all.
 	 *
-	 * @return array
+	 * @return bool|string[] Filtered array of block type slugs, or false if all blocks are disabled.
 	 */
 	public function remove_comment_blocks( $allowed_block_types ) {
 		// A list of disallowed comment blocks.
@@ -437,8 +437,13 @@ class Comments {
 		 */
 		$disallowed_blocks = apply_filters( 'tenup_experience_disable_comments_disallowed_blocks', $disallowed_blocks );
 
-		// Get all registered blocks if $allowed_block_types is not already set.
-		if ( ! is_array( $allowed_block_types ) || empty( $allowed_block_types ) ) {
+		// Respect other filters that have disabled all blocks.
+		if ( false === $allowed_block_types ) {
+			return false;
+		}
+
+		// Get all registered blocks if all blocks are allowed or no explicit list is set.
+		if ( true === $allowed_block_types || ! is_array( $allowed_block_types ) || empty( $allowed_block_types ) ) {
 			$registered_blocks   = \WP_Block_Type_Registry::get_instance()->get_all_registered();
 			$allowed_block_types = array_keys( $registered_blocks );
 

--- a/includes/classes/Comments/Comments.php
+++ b/includes/classes/Comments/Comments.php
@@ -442,11 +442,13 @@ class Comments {
 			return false;
 		}
 
-		// Get all registered blocks if all blocks are allowed or no explicit list is set.
-		if ( true === $allowed_block_types || ! is_array( $allowed_block_types ) || empty( $allowed_block_types ) ) {
+		// Expand to every registered block only when all blocks are allowed (true) or
+		// the value is not an explicit list. An empty array is NOT "no list set" — it
+		// is a deliberate deny-all (WordPress treats `[]` the same as `false`), so it
+		// must be left untouched rather than expanded to every block.
+		if ( true === $allowed_block_types || ! is_array( $allowed_block_types ) ) {
 			$registered_blocks   = \WP_Block_Type_Registry::get_instance()->get_all_registered();
 			$allowed_block_types = array_keys( $registered_blocks );
-
 		}
 
 		// Create a new array for the allowed blocks.


### PR DESCRIPTION
### Description of the Change

Fixes an edge case in the disabled-comments block allowlist filter.

When another `allowed_block_types_all` filter has already returned `false`, WordPress interprets that as "no blocks allowed." The current comments filter replaces that value with a full registered-block allowlist minus comment blocks, which unintentionally re-enables blocks that an earlier filter disabled.

This change preserves `false` and only builds a filtered block list when blocks are otherwise allowed.

### Benefits

- Preserves WordPress/core filter semantics.
- Avoids overriding stricter block restrictions from another plugin, theme, or project filter.
- Keeps the existing comment-block removal behavior for normal `true` or array allowlists.

### Possible Drawbacks

None expected. This only changes behavior when a previous filter has already disabled all blocks.

### Verification Process

- `php -l includes/classes/Comments/Comments.php`
- `composer run lint`
- `git diff --check`

### Changelog Entry

> Fixed - Preserve disabled block allowlists when removing comment blocks.

### Checklist:

- [x] My code follows the code style of this project.
- [x] All new and existing tests pass. _(No automated test suite exists in this repo; CI runs lint only.)_

### A note on tests

This change has unit-testable logic, but the plugin currently ships no test harness (no PHPUnit or e2e setup; CI runs lint only), so there's nothing here to add coverage to. I'm happy to contribute a minimal test setup plus coverage for this in a separate PR if that's welcome.

_AI assistance was used in drafting and reviewing this change; final authorship and verification are mine._
