### PR TITLE
Cache and validate HIBP prefix responses

### DIFF
--- a/includes/classes/Authentication/Passwords.php
+++ b/includes/classes/Authentication/Passwords.php
@@ -451,10 +451,18 @@ class Passwords {
 		}
 
 		if ( ! $cached ) {
+			// wp_remote_get accepts a float timeout; casting to int truncates a fractional
+			// filter value, and 0 (from an invalid/empty return) means "no timeout" — a hang
+			// risk. Allow floats and floor invalid values.
+			$timeout = (float) apply_filters( 'tenup_experience_hibp_request_timeout', 2 );
+			if ( $timeout <= 0 ) {
+				$timeout = 2;
+			}
+
 			$response = wp_remote_get(
 				self::HIBP_API_URL . $prefix,
 				[
-					'timeout'             => (int) apply_filters( 'tenup_experience_hibp_request_timeout', 2 ),
+					'timeout'             => $timeout,
 					'limit_response_size' => $limit,
 					'user-agent'          => '10up Experience WordPress Plugin',
 					// Ask HIBP to pad the response so its size cannot reveal how many

--- a/includes/classes/Authentication/Passwords.php
+++ b/includes/classes/Authentication/Passwords.php
@@ -424,25 +424,43 @@ class Passwords {
 		$prefix = substr( $hash, 0, 5 );
 		$suffix = substr( $hash, 5 );
 
-		$cache_key = 'prefix_' . $prefix;
-		$body      = wp_cache_get( $cache_key, self::HIBP_CACHE_KEY );
+		/**
+		 * Filter the largest range response accepted from the HIBP API, in bytes.
+		 *
+		 * A padded range response is roughly 30-50KB. The cap bounds what a hijacked
+		 * or proxied endpoint can stream into memory, and doubles as the truncation
+		 * boundary below.
+		 *
+		 * @param int $limit Maximum response size in bytes.
+		 */
+		$limit = max( 1024, (int) apply_filters( 'tenup_experience_hibp_max_response_bytes', 128 * 1024 ) );
 
-		if ( false === $body ) {
-			$transient_key = self::HIBP_CACHE_KEY . '_' . strtolower( $cache_key );
-			$body          = get_transient( $transient_key );
+		$cache_key     = 'prefix_' . $prefix;
+		$transient_key = self::HIBP_CACHE_KEY . '_' . strtolower( $cache_key );
+		$body          = wp_cache_get( $cache_key, self::HIBP_CACHE_KEY );
+		$cached        = false !== $body;
+
+		if ( ! $cached ) {
+			$body   = get_transient( $transient_key );
+			$cached = false !== $body;
 
 			// Warm the object cache from the transient so repeat lookups skip the DB read.
-			if ( false !== $body ) {
+			if ( $cached ) {
 				wp_cache_set( $cache_key, $body, self::HIBP_CACHE_KEY, 4 * HOUR_IN_SECONDS );
 			}
 		}
 
-		if ( false === $body ) {
+		if ( ! $cached ) {
 			$response = wp_remote_get(
 				self::HIBP_API_URL . $prefix,
 				[
-					'timeout'    => (int) apply_filters( 'tenup_experience_hibp_request_timeout', 2 ),
-					'user-agent' => '10up Experience WordPress Plugin',
+					'timeout'             => (int) apply_filters( 'tenup_experience_hibp_request_timeout', 2 ),
+					'limit_response_size' => $limit,
+					'user-agent'          => '10up Experience WordPress Plugin',
+					// Ask HIBP to pad the response so its size cannot reveal how many
+					// real matches the prefix held. Padded rows carry a count of 0 and
+					// are skipped when scanning for the suffix below.
+					'headers'             => [ 'Add-Padding' => 'true' ],
 				]
 			);
 
@@ -453,24 +471,45 @@ class Passwords {
 				return true;
 			}
 
-			$body = wp_remote_retrieve_body( $response );
+			$body = (string) wp_remote_retrieve_body( $response );
 
-			if ( empty( $body ) ) {
+			// Check the transport boundary before trimming. A capped response can end
+			// exactly on a CRLF, and trimming first would hide those bytes and make a
+			// truncated range look complete enough to validate and cache. A truncated
+			// range is the dangerous case: the missing tail is indistinguishable from
+			// "not breached", so a real match would read as clean.
+			if ( strlen( $body ) >= $limit ) {
 				return true;
 			}
+		}
 
-			// Cache the prefix response only. Avoid storing full password hashes.
+		$body = trim( (string) $body );
+
+		// Treat an empty or malformed range as unavailable rather than parsing it as
+		// "no match". Every line is a 35-character hash suffix, a colon, and a count;
+		// an HTML error page served with a 200, or a partial final line, is not a
+		// range response and must not be trusted or cached.
+		if ( '' === $body || ! preg_match( '/\A[0-9A-F]{35}:[0-9]+(?:\r?\n[0-9A-F]{35}:[0-9]+)*\z/i', $body ) ) {
+			return true;
+		}
+
+		if ( ! $cached ) {
+			// Cache the validated prefix response only. Avoid storing full password hashes.
 			wp_cache_set( $cache_key, $body, self::HIBP_CACHE_KEY, 4 * HOUR_IN_SECONDS );
 			set_transient( $transient_key, $body, 4 * HOUR_IN_SECONDS );
 		}
 
-		$lines = explode( "\r\n", $body );
+		foreach ( preg_split( '/\r\n|\n/', $body ) as $line ) {
+			$parts = explode( ':', trim( $line ), 2 );
 
-		foreach ( $lines as $line ) {
-			$parts = explode( ':', $line );
+			if ( 2 !== count( $parts ) ) {
+				continue;
+			}
 
-			// If the suffix is found in the response, the password may be in a breach.
-			if ( isset( $parts[0] ) && $parts[0] === $suffix ) {
+			// A row with a count of 0 is padding, not a breach match. Compare the
+			// suffix case-insensitively: the API returns upper-case hex, but the
+			// cached body is only guaranteed to match the validation pattern above.
+			if ( (int) $parts[1] > 0 && 0 === strcasecmp( $parts[0], $suffix ) ) {
 				$is_password_secure = false;
 				break;
 			}

--- a/includes/classes/Authentication/Passwords.php
+++ b/includes/classes/Authentication/Passwords.php
@@ -424,26 +424,44 @@ class Passwords {
 		$prefix = substr( $hash, 0, 5 );
 		$suffix = substr( $hash, 5 );
 
-		$cached_result = wp_cache_get( $prefix . $suffix, self::HIBP_CACHE_KEY );
+		$cache_key = 'prefix_' . $prefix;
+		$body      = wp_cache_get( $cache_key, self::HIBP_CACHE_KEY );
 
-		if ( false !== $cached_result || false ) { // remove || false; only used for testing
-			return $cached_result;
+		if ( false === $body ) {
+			$transient_key = self::HIBP_CACHE_KEY . '_' . strtolower( $cache_key );
+			$body          = get_transient( $transient_key );
+
+			// Warm the object cache from the transient so repeat lookups skip the DB read.
+			if ( false !== $body ) {
+				wp_cache_set( $cache_key, $body, self::HIBP_CACHE_KEY, 4 * HOUR_IN_SECONDS );
+			}
 		}
 
-		$response = wp_remote_get( self::HIBP_API_URL . $prefix, [ 'user-agent' => '10up Experience WordPress Plugin' ] );
+		if ( false === $body ) {
+			$response = wp_remote_get(
+				self::HIBP_API_URL . $prefix,
+				[
+					'timeout'    => (int) apply_filters( 'tenup_experience_hibp_request_timeout', 2 ),
+					'user-agent' => '10up Experience WordPress Plugin',
+				]
+			);
 
-		// Allow for a failed request to the HIPB API.
-		// Don't cache the result if the request failed.
-		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
-			return true;
-		}
+			// If the request fails or times out, fail open: allow the password rather than
+			// blocking the user on an unreachable third-party API. The result is not cached,
+			// so the next attempt retries the check.
+			if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
+				return true;
+			}
 
-		$body = wp_remote_retrieve_body( $response );
+			$body = wp_remote_retrieve_body( $response );
 
-		// Allow for a failed request to the HIPB API.
-		// Don't cache the result if the request failed.
-		if ( is_wp_error( $body ) ) {
-			return true;
+			if ( empty( $body ) ) {
+				return true;
+			}
+
+			// Cache the prefix response only. Avoid storing full password hashes.
+			wp_cache_set( $cache_key, $body, self::HIBP_CACHE_KEY, 4 * HOUR_IN_SECONDS );
+			set_transient( $transient_key, $body, 4 * HOUR_IN_SECONDS );
 		}
 
 		$lines = explode( "\r\n", $body );
@@ -452,13 +470,11 @@ class Passwords {
 			$parts = explode( ':', $line );
 
 			// If the suffix is found in the response, the password may be in a breach.
-			if ( $parts[0] === $suffix ) {
+			if ( isset( $parts[0] ) && $parts[0] === $suffix ) {
 				$is_password_secure = false;
+				break;
 			}
 		}
-
-		// Cache the result for 4 hours.
-		wp_cache_set( $prefix . $suffix, (int) $is_password_secure, self::HIBP_CACHE_KEY, 60 * 60 * 4 );
 
 		return $is_password_secure;
 	}


### PR DESCRIPTION
### Description of the Change

Improves how the Have I Been Pwned check handles its range response: caches the k-anonymity **prefix** response rather than a per-password result, sets an explicit request timeout, and validates that the response actually arrived intact before trusting or caching it.

Previously the result was cached per full password hash, which avoids repeat checks for the same password but does not reuse the HIBP range response for different passwords sharing the same prefix. This change caches the prefix response in object cache and a transient, then checks the local suffix list for the submitted password hash.

The second commit closes the gap that caching opens. Any non-empty 200 was parsed and cached for four hours, so a response cut short at the transport boundary — or an error page served with a `200` by a captive portal or proxy — read as "not breached", and then kept reading that way for the rest of the cache lifetime. The missing tail of a truncated range is indistinguishable from a clean verdict, which is the failure worth closing before a cached body can extend it.

Now:

- **`Add-Padding` is requested**, so the response size cannot reveal how many real matches the prefix held. Padded rows carry a count of `0`, so the suffix scan also requires `count > 0` — without that check, enabling padding would produce false positives.
- **`limit_response_size`** bounds what a hijacked or proxied endpoint can stream into memory. Default 128KB (a padded range is roughly 30–50KB), filterable via `tenup_experience_hibp_max_response_bytes`, floored at 1KB so a filter cannot make every response look truncated.
- **The size check runs before `trim()`.** A capped body can end exactly on a CRLF, and trimming first would hide the truncation and make a partial range look complete enough to validate and cache.
- **The body must match the range format** — 35 hex characters, a colon, a count, one row per line — before it is used at all.
- **Only a validated body is cached.**
- Suffix comparison is case-insensitive, and `$transient_key` is hoisted so it is no longer assigned in one branch and read from another.

The HTTP request also has a short default timeout, filterable with `tenup_experience_hibp_request_timeout`.

Fails open at every step, exactly as before: an unreachable, truncated, or malformed response allows the password rather than blocking password changes while a third-party API is having a bad day.

### Benefits

- Reduces repeated outbound HIBP requests for the same SHA-1 prefix.
- Avoids caching full-hash pass/fail results.
- A truncated or malformed response can no longer be read as "not breached", or cached as such.
- Response size no longer leaks how many suffixes share a prefix.
- Prevents password-validation requests from waiting on the WordPress HTTP API default timeout.
- Keeps the existing k-anonymity request model.

### Possible Drawbacks

The prefix response may be reused for up to four hours, so newly-added HIBP entries for an already-cached prefix may not be seen until the cache expires.

Requesting padding makes responses larger — roughly 30–50KB rather than ~20KB — in exchange for a constant-size signal on the wire. The 128KB cap is well clear of that, and is filterable for anyone who wants it tighter.

### Verification Process

- `php -l includes/classes/Authentication/Passwords.php`
- `composer lint` — clean; the four warnings the full run reports are pre-existing on `develop` in `AdminCustomizations/EnvironmentIndicator.php` and are untouched here.
- `git diff --check`
- The parsing decisions were exercised against hand-built bodies: a body at and over the cap, a capped body ending exactly on CRLF, an HTML error page with a `200`, a partial trailing line, a padded (`:0`) row, a real match, and lower-case hex.

### Changelog Entry

> Fixed - Cache Have I Been Pwned prefix responses, add a request timeout, and reject truncated or malformed range responses instead of treating them as a clean result.

### Checklist:

- [x] My code follows the code style of this project.
- [x] All new and existing tests pass. _(No automated test suite exists in this repo; CI runs lint only.)_

### A note on tests

As mentioned before: this change has unit-testable logic, but the plugin ships no test harness (no PHPUnit or e2e setup; CI runs lint only), so there is nothing here to add coverage to.

That offer is now concrete. I have a dependency-free test file covering exactly the branches added here — truncation at and over the cap, the CRLF-at-boundary case, HTML bodies, partial trailing lines, padded rows, case-insensitive suffix matching, and the opt-out path. It stubs the handful of WordPress functions involved and runs as `php tests/hibp.php`, so it needs no PHPUnit and no bootstrap. Happy to open it as a separate PR if a minimal harness of that shape is welcome, or to rewrite it for PHPUnit if you would rather start there.

_AI assistance was used in drafting and reviewing this change; final authorship and verification are mine._
