### PR TITLE
Add SSO proxy request timeout

### DIFF
--- a/includes/classes/SSO/SSO.php
+++ b/includes/classes/SSO/SSO.php
@@ -229,7 +229,12 @@ class SSO {
 				TENUPSSO_PROXY_URL
 			);
 
-			$response = wp_remote_get( $verify );
+			$response = wp_remote_get(
+				$verify,
+				[
+					'timeout' => (int) apply_filters( 'tenup_experience_sso_proxy_request_timeout', 5 ),
+				]
+			);
 
 			if ( wp_remote_retrieve_response_code( $response ) !== 200 ) {
 				wp_safe_redirect( wp_login_url() );

--- a/includes/classes/SSO/SSO.php
+++ b/includes/classes/SSO/SSO.php
@@ -229,10 +229,18 @@ class SSO {
 				TENUPSSO_PROXY_URL
 			);
 
+			// wp_remote_get accepts a float timeout; casting to int truncates a fractional
+			// filter value, and 0 (from an invalid/empty return) means "no timeout" — a hang
+			// risk. Allow floats and floor invalid values.
+			$timeout = (float) apply_filters( 'tenup_experience_sso_proxy_request_timeout', 5 );
+			if ( $timeout <= 0 ) {
+				$timeout = 5;
+			}
+
 			$response = wp_remote_get(
 				$verify,
 				[
-					'timeout' => (int) apply_filters( 'tenup_experience_sso_proxy_request_timeout', 5 ),
+					'timeout' => $timeout,
 				]
 			);
 


### PR DESCRIPTION
### Description of the Change

Adds an explicit timeout to the SSO proxy verification request.

The SSO login flow performs an outbound request to the configured proxy. This change sets a default five-second timeout and makes it filterable with `tenup_experience_sso_proxy_request_timeout`.

### Benefits

- Avoids relying on the WordPress HTTP API default timeout during login.
- Gives projects a small extension point to tune SSO proxy timeout behavior.
- Leaves the existing success/failure behavior unchanged.

### Possible Drawbacks

If an SSO proxy regularly takes more than five seconds to respond, projects may need to increase the timeout with the provided filter.

### Verification Process

- `php -l includes/classes/SSO/SSO.php`
- `composer run lint`
- `git diff --check`

### Changelog Entry

> Fixed - Add a timeout to SSO proxy verification requests.

### Checklist:

- [x] My code follows the code style of this project.
- [x] All new and existing tests pass. _(No automated test suite exists in this repo; CI runs lint only.)_

_AI assistance was used in drafting and reviewing this change; final authorship and verification are mine._
