### PR TITLE
Validate the password WordPress stores, not a sanitized copy of it

### DIFF
--- a/includes/classes/Authentication/Passwords.php
+++ b/includes/classes/Authentication/Passwords.php
@@ -317,7 +317,7 @@ class Passwords {
 		$enforce     = true;
 		// This is being sanitized later in the function, no need to sanitize for isset().
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$password = ( isset( $_POST['pass1'] ) && trim( $_POST['pass1'] ) ) ? sanitize_text_field( $_POST['pass1'] ) : false;
+		$password = ( isset( $_POST['pass1'] ) && '' !== $_POST['pass1'] ) ? sanitize_text_field( $_POST['pass1'] ) : false;
 		$role     = isset( $_POST['role'] ) ? sanitize_text_field( $_POST['role'] ) : false;
 		$user_id  = isset( $user_data->ID ) ? sanitize_text_field( $user_data->ID ) : false;
 		$username = isset( $_POST['user_login'] ) ? sanitize_text_field( $_POST['user_login'] ) : $user_data->user_login;

--- a/includes/classes/Authentication/Passwords.php
+++ b/includes/classes/Authentication/Passwords.php
@@ -322,7 +322,11 @@ class Passwords {
 		// whitespace, and removes octets, so the strength and breach checks below would
 		// judge a string the user never chose.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Passwords must not be sanitized.
-		$password = ( isset( $_POST['pass1'] ) && '' !== $_POST['pass1'] ) ? (string) wp_unslash( $_POST['pass1'] ) : false;
+		$raw_pass1 = isset( $_POST['pass1'] ) ? wp_unslash( $_POST['pass1'] ) : '';
+		// A crafted request can submit pass1 as an array ( pass1[]=... ); the '' !== check
+		// passed for an array and (string) coerced it to "Array" with a PHP warning. Treat
+		// any non-string as no password.
+		$password = ( is_string( $raw_pass1 ) && '' !== $raw_pass1 ) ? $raw_pass1 : false;
 		$role     = isset( $_POST['role'] ) ? sanitize_text_field( $_POST['role'] ) : false;
 		$user_id  = isset( $user_data->ID ) ? sanitize_text_field( $user_data->ID ) : false;
 		$username = isset( $_POST['user_login'] ) ? sanitize_text_field( $_POST['user_login'] ) : $user_data->user_login;

--- a/includes/classes/Authentication/Passwords.php
+++ b/includes/classes/Authentication/Passwords.php
@@ -315,9 +315,14 @@ class Passwords {
 	public function validate_strong_password( $errors, $user_data ) {
 		$password_ok = true;
 		$enforce     = true;
-		// This is being sanitized later in the function, no need to sanitize for isset().
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$password = ( isset( $_POST['pass1'] ) && '' !== $_POST['pass1'] ) ? sanitize_text_field( $_POST['pass1'] ) : false;
+		// Validate the password WordPress will actually store, which means unslashing
+		// it and sanitizing nothing: edit_user() takes $_POST['pass1'] as-is (rejecting
+		// any password containing a backslash) and wp_insert_user() unslashes before
+		// hashing. Passing it through sanitize_text_field() strips tags, collapses
+		// whitespace, and removes octets, so the strength and breach checks below would
+		// judge a string the user never chose.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Passwords must not be sanitized.
+		$password = ( isset( $_POST['pass1'] ) && '' !== $_POST['pass1'] ) ? (string) wp_unslash( $_POST['pass1'] ) : false;
 		$role     = isset( $_POST['role'] ) ? sanitize_text_field( $_POST['role'] ) : false;
 		$user_id  = isset( $user_data->ID ) ? sanitize_text_field( $user_data->ID ) : false;
 		$username = isset( $_POST['user_login'] ) ? sanitize_text_field( $_POST['user_login'] ) : $user_data->user_login;


### PR DESCRIPTION
### Summary

`Passwords::validate_strong_password()` mishandles `$_POST['pass1']` in two ways, and both mean the policy is applied to something other than the password being set.

**1. The blank-field test uses `trim()` as a boolean.** That treats an all-whitespace value (`"   "`) — and, because the trimmed result is evaluated as a boolean, a value of `"0"` — as "no password set", so the function returns early and skips its zxcvbn and Have I Been Pwned checks.

This one is harmless in practice: core already rejects a whitespace-only password on every path, so one cannot actually be set or used through the UI.

- `edit_user()` trims `pass1` and only saves `if ( ! empty( $pass1 ) )` → `"   "` becomes a no-op change.
- The reset-password form errors with "The password cannot be a space or all spaces." before `reset_password()` is called.
- At login, `wp_authenticate()` trims the entry and `wp_authenticate_username_password()` rejects an empty password.

So it is not a policy bypass — the blank-field test should simply key off an empty *field*, so the plugin's own checks do not silently skip.

**2. The password is passed through `sanitize_text_field()` before validation.** This one has teeth. That function strips tags, collapses whitespace, and removes octets, so the length, zxcvbn, and HIBP checks all run against a string the user did not choose and WordPress will not store.

Concretely, `my<b>secret phrase` is validated as `mysecret phrase`: a different length, a different zxcvbn score, and a different SHA-1 prefix sent to HIBP. The verdict returned is real — it just belongs to a different password. In practice this surfaces as confusing rejections (a fine password scored as something weaker, or matched against a breach entry the user never used), and it means the breach check does not actually cover the credential that ends up in the database.

Core never sanitizes here, and passwords are the standard example of a value that must not be sanitized. `edit_user()` takes `$_POST['pass1']` as-is — rejecting any password containing a backslash — and `wp_insert_user()` unslashes before hashing, so `wp_unslash( $_POST['pass1'] )` is exactly the string that gets hashed.

### Fix

```diff
-$password = ( isset( $_POST['pass1'] ) && trim( $_POST['pass1'] ) ) ? sanitize_text_field( $_POST['pass1'] ) : false;
+$password = ( isset( $_POST['pass1'] ) && '' !== $_POST['pass1'] ) ? (string) wp_unslash( $_POST['pass1'] ) : false;
```

Only a genuinely empty field means "no change", and what gets validated is what gets stored. The `phpcs:ignore` stays, now with a reason on it: not sanitizing is the point.

Legitimate password changes are unaffected, except that passwords containing markup, doubled spaces, or trailing whitespace are now judged as themselves.

### Verification Process

- `php -l includes/classes/Authentication/Passwords.php`
- `composer lint` — clean; the four warnings the full run reports are pre-existing on `develop` in `AdminCustomizations/EnvironmentIndicator.php` and are untouched here.
- `git diff --check`
- Checked against core: `wp-admin/includes/user.php` (`edit_user()` trim and backslash rejection) and `wp_insert_user()`'s `wp_unslash()` before hashing.

### Changelog Entry

> Fixed - Validate the password WordPress actually stores: the strong-password checks no longer run against a sanitized copy, and a whitespace-only or "0" entry no longer skips them.

### Checklist:

- [x] My code follows the code style of this project.
- [x] All new and existing tests pass. _(No automated test suite exists in this repo; CI runs lint only.)_

_AI assistance was used in drafting and reviewing this change; final authorship and verification are mine._
